### PR TITLE
Preprared automated builds of Docker Images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Build and Push Image samply/lens-web-components
+
+on:
+  push:
+    branches:
+      - main
+    # Build then a new version is tagged
+    tags:
+      - '*.*.*'
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Build every night at 1am
+    - cron: '0 1 * * *'
+jobs:
+  build:
+    # This workflow defines how a samply docker image is built, tested and published.
+    # Visit: https://github.com/samply/github-workflows/blob/main/.github/workflows/docker-ci.yml, for more information
+    uses: samply/github-workflows/.github/workflows/docker-ci.yml@main
+    with:
+      image-name: "samply/lens-web-components"
+    # This passes the secrets from calling workflow to the called workflow
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/packages/demo/src/AppCCP.svelte
+++ b/packages/demo/src/AppCCP.svelte
@@ -120,7 +120,7 @@
   ];
 
   const backendConfig = {
-    url: "http://localhost:8080",
+    url: "https://backend.demo.lens.samply.de/prod/",
     backends: [
       'mannheim',
       'freiburg',

--- a/packages/lib/src/classes/spot.ts
+++ b/packages/lib/src/classes/spot.ts
@@ -30,7 +30,7 @@ export class Spot {
             `${this.url}tasks?sites=${this.sites.toString()}`,
             {
                 method: 'POST',
-                // credentials: 'include',
+                credentials: 'include',
                 body: query,
             }
         )
@@ -51,7 +51,7 @@ export class Spot {
             const beamResponses: Response = await fetch(
                 `${this.url}tasks/${beamTask.id}?wait_count=${responseCount + 1}&wait_time=${requestTimeOut}ms`,
                 {
-                    // credentials: 'include'
+                    credentials: 'include'
                 }
             )
 


### PR DESCRIPTION
Please note, that we need to keep the changes to spot and AppCCP.svelte for now. If you can separate the different Applications into their own build commands (something like npm build AppCCP), i could integrat that into the Dockerfile and the CI.