### PR TITLE
Handle group range correctly

### DIFF
--- a/packages/lib/src/components/results/ChartComponent.wc.svelte
+++ b/packages/lib/src/components/results/ChartComponent.wc.svelte
@@ -314,7 +314,7 @@
                  */
                 if (isNaN(parseInt(label))) return label;
 
-                return `${parseInt(label)} - ${parseInt(label) + groupRange}`;
+                return `${parseInt(label)} - ${parseInt(label) + groupRange - 1}`;
             });
         }
 
@@ -376,12 +376,10 @@
                                  */
                                 values = [
                                     {
-                                        name: `${label} - ${
-                                            parseInt(label) + 9
-                                        }`,
+                                        name: `${label}`,
                                         value: {
                                             min: parseInt(label),
-                                            max: parseInt(label) + 9,
+                                            max: parseInt(label) + groupRange - 1,
                                         },
                                         queryBindId: uuidv4(),
                                     },


### PR DESCRIPTION
This fixes the chips that are displaying (60 -70 - 69).  After the merge only (60 - 69) will be displayed.
Also, if the group range is now lager than 10 it should also behave correctly as before the group range value for the criteria was hard coded