### PR TITLE
Fix Histology typo

### DIFF
--- a/packages/demo/public/options.json
+++ b/packages/demo/public/options.json
@@ -166,7 +166,7 @@
                         "groupCode": "specimen"
                     },
                     {
-                        "stratifierCode": "Histlogoies",
+                        "stratifierCode": "Histologies",
                         "stratumCode": "1"
                     },
                     {

--- a/packages/demo/src/measures.ts
+++ b/packages/demo/src/measures.ts
@@ -1034,11 +1034,11 @@ export const dktkHistologyMeasure = {
         stratifier: [
             {
                 code: {
-                    text: "Histlogoies",
+                    text: "Histologies",
                 },
                 criteria: {
                     language: "text/cql-identifier",
-                    expression: "Histlogoy",
+                    expression: "Histology",
                 },
             },
         ],


### PR DESCRIPTION
This fixes a typo in histologies and requires three pull requests to work:
- https://github.com/samply/lens/pull/85
- https://github.com/samply/focus/pull/130
- https://github.com/samply/prism/pull/16