### PR TITLE
Feat(catalogue): select all button for single-select elements

### DIFF
--- a/packages/demo/public/options.json
+++ b/packages/demo/public/options.json
@@ -1,6 +1,9 @@
 {
     "iconOptions": {
-        "infoUrl": "info-circle-svgrepo-com.svg"
+        "infoUrl": "info-circle-svgrepo-com.svg",
+        "selectAll": {
+            "text": "Add all"
+        }
     },
     "chartOptions": {
         "patients": {

--- a/packages/lib/src/components/Options.wc.svelte
+++ b/packages/lib/src/components/Options.wc.svelte
@@ -35,6 +35,22 @@
                     ) {
                         store.set("infoUrl", options.iconOptions.infoUrl);
                     }
+                    if (
+                        "selectAll" in options.iconOptions &&
+                        typeof options.iconOptions["selectAll"] === "object" &&
+                        options.iconOptions.selectAll
+                    ) {
+                        // Allow for future possibility of iconUrl instead of text
+                        if (
+                            "text" in options.iconOptions.selectAll &&
+                            typeof options.iconOptions.selectAll["text"] ===
+                                "string"
+                        )
+                            store.set(
+                                "selectAllText",
+                                options.iconOptions.selectAll.text,
+                            );
+                    }
                 }
             }
 

--- a/packages/lib/src/styles/catalogue.css
+++ b/packages/lib/src/styles/catalogue.css
@@ -52,6 +52,17 @@ lens-catalogue::part(data-tree-element-toggle-icon) {
   transition: all 0.1s ease-in-out;
 }
 
+lens-catalogue::part(add-all-options-button) {
+  background-color: var(--button-background-color);
+  border-radius: var(--border-radius-small);
+  color: var(--button-color);
+  position: relative;
+  padding: 3px 8px;
+  cursor: pointer;
+  border: none;
+  left: +15px;
+}
+
 lens-catalogue::part(data-tree-element-toggle-icon-open) {
   transform: rotate(0deg);
 }


### PR DESCRIPTION
### General Summary
Select all `single-select` query elements under a subcategory to add to the query.

### Description
Previously, all elements had to added individually to the query if using the catalogue drop down menu. Now, if query elements are of the type `single-select` they can be added to the query using the `[Add all]` button.

### Related Issue
![Screenshot 2024-04-15 at 13 35 28](https://github.com/samply/lens/assets/85494988/1af72aef-1a43-471c-9a22-d6d114534ba1)

In English:
![Screenshot 2024-04-15 at 13 36 13](https://github.com/samply/lens/assets/85494988/8af51d6a-be5e-443c-b56f-0ebbe714bf4b)

---

### Motivation and Context
This should allow for faster querying in the event all options of subcategories are needed.

### How Has This Been Tested?
This was run on a local MacOS development environment based on the latest `develop` branch.

### Screenshots (if appropriate):
<img width="948" alt="Screenshot 2024-04-15 at 13 39 18" src="https://github.com/samply/lens/assets/85494988/d5662c61-dcf9-4a01-989e-5d9e8a4cf624">

---

<!--- Please check if the PR fulfills these requirements -->
- [X] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [X] Documentation has been added/ updated