### PR TITLE
Removed upgrade from http to https

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,8 @@ services:
     command:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
-      - --entrypoints.web.http.redirections.entrypoint.to=websecure
-      - --entrypoints.web.http.redirections.entrypoint.scheme=https
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --providers.file.directory=/conf/
       - --accesslog=true
     ports:
       - "80:80"


### PR DESCRIPTION
### General Summary
Don't include upgrade from http to https in the default configuration.
### Description
Some Servers may need to be accessed via http by another reverse proxy, that is put up by the institute hosting the server. 

### Related Issue
As we need to change this locally on the production machine (removing the redirect) updates for git are not automatically received on that server. The only proper solution is to add the redirect to the testing machine.
