### PR TITLE
feat(number input): add min and max values

### DIFF
--- a/packages/demo/public/catalogues/catalogue-dktk.json
+++ b/packages/demo/public/catalogues/catalogue-dktk.json
@@ -7115,6 +7115,8 @@
                 "system": "",
                 "fieldType": "number",
                 "type": "BETWEEN",
+                "min": 1900,
+                "max": 2040,
                 "criteria": []
             },
             {
@@ -7123,6 +7125,8 @@
                 "system": "",
                 "fieldType": "number",
                 "type": "BETWEEN",
+                "min": 0,
+                "max": 150,
                 "criteria": []
             },
             {

--- a/packages/lib/src/components/catalogue/DataTreeElement.svelte
+++ b/packages/lib/src/components/catalogue/DataTreeElement.svelte
@@ -224,6 +224,7 @@
                 {:else if "fieldType" in element && element.fieldType === "number"}
                     {#each numberInput.values as numberInputValues (numberInputValues.queryBindId)}
                         <NumberInputComponent
+                            {element}
                             queryItem={{
                                 ...numberInput,
                                 values: [numberInputValues],

--- a/packages/lib/src/components/catalogue/NumberInputComponent.svelte
+++ b/packages/lib/src/components/catalogue/NumberInputComponent.svelte
@@ -31,9 +31,9 @@
                 ? element.max
                 : null;
 
-        if (min && from <= min) {
+        if (min !== null && from <= min) {
             from = min;
-        } else if (max && from >= max) {
+        } else if (max !== null && from >= max) {
             from = max;
         }
     };
@@ -54,9 +54,9 @@
                 ? element.max
                 : null;
 
-        if (min && to <= min) {
+        if (min !== null && to <= min) {
             to = min;
-        } else if (max && to >= max) {
+        } else if (max !== null && to >= max) {
             to = max;
         }
     };

--- a/packages/lib/src/components/catalogue/NumberInputComponent.svelte
+++ b/packages/lib/src/components/catalogue/NumberInputComponent.svelte
@@ -4,17 +4,62 @@
     import { catalogueTextStore } from "../../stores/texts";
     import QueryAddButtonComponent from "./QueryAddButtonComponent.svelte";
     import { activeNumberInputs } from "../../stores/catalogue";
+    import type { Category } from "../../types/treeData";
 
     export let queryItem: QueryItem;
+    export let element: Category;
 
     const queryBindId = queryItem.values[0].queryBindId;
     const value = queryItem.values[0].value as { min: number; max: number };
 
-    /**
-     * defines and handles the number inputs
-     */
     let from: number | null = value.min;
     let to: number | null = value.max;
+
+    /**
+     * handles the "from" input field
+     * when the catalogue element has min or max values, they are used on focus out if the input is out of bounds
+     */
+    const handleInputFrom = (): void => {
+        if (from === null) return;
+
+        let min: number | null =
+            "min" in element && typeof element.min === "number"
+                ? element.min
+                : null;
+        let max: number | null =
+            "max" in element && typeof element.max === "number"
+                ? element.max
+                : null;
+
+        if (min && from <= min) {
+            from = min;
+        } else if (max && from >= max) {
+            from = max;
+        }
+    };
+
+    /**
+     * handles the "to" input field
+     * when the catalogue element has min or max values, they are used on focus out if the input is out of bounds
+     */
+    const handleInputTo = (): void => {
+        if (to === null) return;
+
+        let min: number | null =
+            "min" in element && typeof element.min === "number"
+                ? element.min
+                : null;
+        let max: number | null =
+            "max" in element && typeof element.max === "number"
+                ? element.max
+                : null;
+
+        if (min && to <= min) {
+            to = min;
+        } else if (max && to >= max) {
+            to = max;
+        }
+    };
 
     /**
      * build the proper name for the query value
@@ -95,7 +140,7 @@
                         {to && from > to ? ' formfield-error' : ''}"
                     type="number"
                     bind:value={from}
-                    min="0"
+                    on:focusout={handleInputFrom}
                 />
             </label>
 
@@ -108,7 +153,7 @@
                         {to && from > to ? ' formfield-error' : ''}"
                     type="number"
                     bind:value={to}
-                    min="0"
+                    on:focusout={handleInputTo}
                 />
             </label>
         </div>

--- a/packages/lib/src/interfaces/catalogue.schema.json
+++ b/packages/lib/src/interfaces/catalogue.schema.json
@@ -53,6 +53,12 @@
                         "BETWEEN"
                     ]
                 },
+                "min": {
+                    "type": "number"
+                },
+                "max": {
+                    "type": "number"
+                },
                 "childCategories": {
                     "$ref": "#/$defs/childCategories"
                 },

--- a/packages/lib/src/types/treeData.ts
+++ b/packages/lib/src/types/treeData.ts
@@ -1,32 +1,41 @@
-export type TreeNode = Category[] |Category | Criteria | AggregatedValue[] | AggregatedValue
+export type TreeNode =
+    | Category[]
+    | Category
+    | Criteria
+    | AggregatedValue[]
+    | AggregatedValue;
 
-export type Category = {
-    key: string;
-    name: string;
-    childCategories?: Category[];
-    infoButtonText?: string[];
-    subCategoryName?: string;
-} | {
-    key: string;
-    name: string;
-    system?: string;
-    fieldType: 'single-select' | 'autocomplete' | 'number';
-    type: 'EQUALS' | 'BETWEEN';
-    criteria: | Criteria[];
-    description?: string;
-    infoButtonText?: string[];
-}
+export type Category =
+    | {
+          key: string;
+          name: string;
+          childCategories?: Category[];
+          infoButtonText?: string[];
+          subCategoryName?: string;
+      }
+    | {
+          key: string;
+          name: string;
+          system?: string;
+          fieldType: "single-select" | "autocomplete" | "number";
+          type: "EQUALS" | "BETWEEN";
+          min?: number;
+          max?: number;
+          criteria: Criteria[];
+          description?: string;
+          infoButtonText?: string[];
+      };
 
 export type Criteria = {
     key: string;
     name: string;
     description?: string;
-    aggregatedValue?: AggregatedValue[][]
-}
+    aggregatedValue?: AggregatedValue[][];
+};
 
 export type AggregatedValue = {
     value: string;
     name: string;
     type: string;
     system?: string;
-}
+};


### PR DESCRIPTION
### General Summary
min and max values can be configured

### Description
the number input fields in the catalogue can have up to one minimum and up to one maximum value

### Motivation and Context
the user should be prevented from entering numbers that make no sense

### How Has This Been Tested?
by hand in the browser

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [x] Documentation has been added/ updated
