### PR TITLE
fix(search bar): display info dialogue to not be cut off

### DIFF
--- a/packages/lib/src/styles/searchbars.css
+++ b/packages/lib/src/styles/searchbars.css
@@ -226,3 +226,8 @@ lens-search-bar-multiple::part(lens-search-button) {
   margin-left: auto;
   margin-right: 45px;
 }
+
+lens-search-bar::part(info-button-dialogue),
+lens-search-bar-multiple::part(info-button-dialogue) {
+  left: 0px;
+}


### PR DESCRIPTION
### General Summary
info text of chips was cut off at left edge
### Description
now the info dialogue is positioned to the right rather than the left

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
