### PR TITLE
feat(catalogue): align style of autocomplete to number input

### DIFF
--- a/packages/demo/src/ccp.css
+++ b/packages/demo/src/ccp.css
@@ -352,6 +352,11 @@ lens-catalogue::part(lens-catalogue) {
   padding-left: 8px;
 }
 
+lens-catalogue::part(autocomplete-formfield-input) {
+  border: solid 1px var(--dark-gray);
+  border-radius: 0;
+}
+
 lens-catalogue::part(autocomplete-formfield-input):focus {
   border-color: var(--light-blue);
 }


### PR DESCRIPTION
### General Summary
align styling of autocomplete and number input
### Description
autocomplete and number input fields now both have square look

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
