### PR TITLE
Fix/catalogue scroll behaviour

### DIFF
--- a/packages/demo/src/AppCCP.svelte
+++ b/packages/demo/src/AppCCP.svelte
@@ -123,51 +123,58 @@
 </script>
 
 <header>
-    <div class="logo">
-        <img src="../dktk.svg" alt="Logo des DKTK" />
-    </div>
-    <h1>CCP Explorer</h1>
-    <div class="logo logo-dkfz">
-        <img
-            src="../Deutsches_Krebsforschungszentrum_Logo.svg"
-            alt="Logo des DKTK"
-        />
+    <div class="header-wrapper">
+        <div class="logo">
+            <img src="../dktk.svg" alt="Logo des DKTK" />
+        </div>
+        <h1>CCP Explorer</h1>
+        <div class="logo logo-dkfz">
+            <img
+                src="../Deutsches_Krebsforschungszentrum_Logo.svg"
+                alt="Logo des DKTK"
+            />
+        </div>
     </div>
 </header>
 <main>
     <div class="search">
-        <lens-search-bar
-            treeData={catalogueData}
-            noMatchesFoundMessage={"keine Ergebnisse gefunden"}
-        />
-        <lens-info-button
-            noQueryMessage="Leere Suchanfrage: Sucht nach allen Ergebnissen."
-            showQuery={true}
-        />
-        <lens-search-button
-            title="Suchen"
-            {measures}
-            backendConfig={JSON.stringify(backendConfig)}
-            {backendMeasures}
-        />
-    </div>
-    <div class="grid">
-        <div class="catalogue">
-            <h2>Suchkriterien</h2>
-            <lens-info-button
-                message={[
-                    `Bei Patienten mit mehreren onkologischen Diagnosen, können sich ausgewählte Suchkriterien nicht nur auf eine Erkrankung beziehen, sondern auch auf Weitere.`,
-                    `Innerhalb einer Kategorie werden verschiedene Ausprägungen mit einer „Oder-Verknüpfung“ gesucht; bei der Suche über mehrere Kategorien mit einer „Und-Verknüpfung“.`,
-                ]}
-            />
-            <lens-catalogue
-                toggleIconUrl="right-arrow-svgrepo-com.svg"
-                addIconUrl="long-right-arrow-svgrepo-com.svg"
-                infoIconUrl="info-circle-svgrepo-com.svg"
+        <div class="search-wrapper">
+            <lens-search-bar
                 treeData={catalogueData}
-                texts={catalogueText}
-                toggle={{ collapsable: false, open: catalogueopen }}
+                noMatchesFoundMessage={"keine Ergebnisse gefunden"}
             />
+            <lens-info-button
+                noQueryMessage="Leere Suchanfrage: Sucht nach allen Ergebnissen."
+                showQuery={true}
+            />
+            <lens-search-button
+                title="Suchen"
+                {measures}
+                backendConfig={JSON.stringify(backendConfig)}
+                {backendMeasures}
+            />
+        </div>
+    </div>
+
+    <div class="grid">
+        <div class="catalogue-wrapper">
+            <div class="catalogue">
+                <h2>Suchkriterien</h2>
+                <lens-info-button
+                    message={[
+                        `Bei Patienten mit mehreren onkologischen Diagnosen, können sich ausgewählte Suchkriterien nicht nur auf eine Erkrankung beziehen, sondern auch auf Weitere.`,
+                        `Innerhalb einer Kategorie werden verschiedene Ausprägungen mit einer „Oder-Verknüpfung“ gesucht; bei der Suche über mehrere Kategorien mit einer „Und-Verknüpfung“.`,
+                    ]}
+                />
+                <lens-catalogue
+                    toggleIconUrl="right-arrow-svgrepo-com.svg"
+                    addIconUrl="long-right-arrow-svgrepo-com.svg"
+                    infoIconUrl="info-circle-svgrepo-com.svg"
+                    treeData={catalogueData}
+                    texts={catalogueText}
+                    toggle={{ collapsable: false, open: catalogueopen }}
+                />
+            </div>
         </div>
         <div class="charts">
             <div class="chart-wrapper result-summary">

--- a/packages/demo/src/ccp.css
+++ b/packages/demo/src/ccp.css
@@ -252,9 +252,6 @@ footer {
   background-color: var(--white);
   border-radius: var(--border-radius-small);
   border: solid 1px var(--lightest-gray);
-  /* position: sticky;
-  position: -webkit-sticky;
-  bottom: 0; */
 }
 
 footer a {

--- a/packages/demo/src/ccp.css
+++ b/packages/demo/src/ccp.css
@@ -69,6 +69,14 @@ button {
 }
 
 header {
+  background-color: var(--ghost-white);
+  position: sticky;
+  top: 0px;
+  z-index: 1;
+  padding: var(--gap-xs);
+}
+
+.header-wrapper {
   background-color: var(--white);
   padding: var(--gap-xs);
   display: grid;
@@ -76,6 +84,7 @@ header {
   grid-template-columns: 1fr 1fr 1fr;
   border-radius: var(--border-radius-small);
   border: solid 1px var(--lightest-gray);
+  
 }
 
 .logo img {
@@ -98,22 +107,26 @@ header h1 {
   margin: 0;
 }
 
-main>div,
-header,
+/* .grid,
 footer {
   margin: var(--gap-xs);
-}
+} */
 
 .search {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  grid-gap: var(--gap-s);
-  padding: var(--gap-xxs) 0;
+  padding: var(--gap-xs) var(--gap-xs) var(--gap-s);
   background-color: var(--ghost-white);
   position: sticky;
   position: -webkit-sticky;
-  top: 0;
+  top: 86px;
   z-index: 1;
+}
+
+.search-wrapper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-gap: var(--gap-s);
+  /* padding: var(--gap-xxs) 0; */
+  background-color: var(--ghost-white);
 }
 
 .grid {
@@ -121,18 +134,25 @@ footer {
   display: grid;
   grid-template-columns: 400px 1fr;
   grid-gap: var(--gap-m);
+  padding: 0 var(--gap-xs) var(--gap-xs);
 }
 
-.catalogue {
-  padding: var(--gap-s);
-  border-radius: var(--border-radius-small);
+.catalogue-wrapper {
+  background-color: var(--white);
   border: solid 1px var(--lightest-gray);
+  border-radius: var(--border-radius-small);
+  }
+  
+  .catalogue {
+  border-radius: var(--border-radius-small);
+  padding: var(--gap-s);
   background-color: var(--white);
   grid-row: 1/-1;
   overflow-y: scroll;
-  height: 100vh;
+  height: calc(100vh - 226px);
   position: sticky;
-  top: 40px;
+  top: 153px;
+  
 }
 
 .catalogue h2 {
@@ -148,6 +168,7 @@ footer {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   grid-gap: var(--gap-xs);
+  grid-column: 2/3;
 }
 
 
@@ -231,9 +252,9 @@ footer {
   background-color: var(--white);
   border-radius: var(--border-radius-small);
   border: solid 1px var(--lightest-gray);
-  position: sticky;
+  /* position: sticky;
   position: -webkit-sticky;
-  bottom: 0;
+  bottom: 0; */
 }
 
 footer a {


### PR DESCRIPTION
### General Summary
Fix the scroll behaviour with sticky elements.

### Motivation and Context
Elements at the bottom of the catalgoue could only be reached when the whole page was scrolled to bottom .
The header is now also sticky while the footer is now at the bottom when scrolling down.

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
