### PR TITLE
feat(result_summary): add samples to summary

### DIFF
--- a/packages/demo/public/options-ccp-demo.json
+++ b/packages/demo/public/options-ccp-demo.json
@@ -208,6 +208,11 @@
             {
                 "title": "Patienten",
                 "dataKey": "patients"
+            },
+            {
+                "title": "Bioproben",
+                "dataKey": "bioproben"
+
             }
         ]
     },

--- a/packages/demo/public/options-dev.json
+++ b/packages/demo/public/options-dev.json
@@ -209,6 +209,10 @@
             {
                 "title": "Patienten",
                 "dataKey": "patients"
+            },
+            {
+                "title": "Bioproben",
+                "dataKey": "bioproben"
             }
         ]
     },


### PR DESCRIPTION
### General Summary
Added number of samples to the overview bar on the right (resultsSummary)

### Description
Please display the total number of biosamples in the overview bar next to locations and patients.
![Screenshot 2024-07-30 124953](https://github.com/user-attachments/assets/419c0bc3-8b08-40ba-994d-1cb48e61ce92)

### Related Issue
Ticket 7 in Confluence

---

### Motivation and Context

### How Has This Been Tested?
This was run in a development environment using `npm start` on MacOs Sonoma 14.5

### Screenshots (if appropriate):
![Screenshot 2024-08-12 at 13 03 04](https://github.com/user-attachments/assets/e89c55cf-5811-4ab1-a0ee-29e060cd4b97)

---

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
