### PR TITLE
Fix(SingleSelectComponent): remove redundant add all

### DIFF
--- a/packages/lib/src/components/catalogue/DataTreeElement.svelte
+++ b/packages/lib/src/components/catalogue/DataTreeElement.svelte
@@ -215,10 +215,7 @@
         {:else}
             <div part="data-tree-element-last-child-options">
                 {#if "fieldType" in element && element.fieldType === "single-select"}
-                    <SingleSelectComponent
-                        {element}
-                        subgrouping={subCategoryName ? true : false}
-                    />
+                    <SingleSelectComponent {element} />
                 {:else if "fieldType" in element && element.fieldType === "autocomplete"}
                     <AutocompleteComponent {element} />
                 {:else if "fieldType" in element && element.fieldType === "number"}

--- a/packages/lib/src/components/catalogue/SingleSelectComponent.svelte
+++ b/packages/lib/src/components/catalogue/SingleSelectComponent.svelte
@@ -1,58 +1,12 @@
 <script lang="ts">
-    import { iconStore } from "../../stores/icons";
-    import { addItemToQuery } from "../../stores/query";
-    import type { QueryItem } from "../../types/queryData";
     import type { Category } from "../../types/treeData";
     import SingleSelectItemComponent from "./SingleSelectItemComponent.svelte";
-    import { v4 as uuidv4 } from "uuid";
 
     export let element: Category;
-    export let subgrouping: boolean = false;
-
-    const addAll = (): void => {
-        if (!("criteria" in element)) return;
-        element.criteria.forEach((criterion) => {
-            const queryItem: QueryItem = {
-                id: uuidv4(),
-                key: element.key,
-                name: element.name,
-                type: "type" in element && element.type,
-                values: [
-                    {
-                        name: criterion.name,
-                        value:
-                            "aggregatedValue" in criterion
-                                ? criterion.aggregatedValue
-                                : criterion.key,
-                        queryBindId: uuidv4(),
-                    },
-                ],
-            };
-            addItemToQuery(queryItem, 0);
-        });
-    };
 </script>
 
 <div part="criterion-wrapper single-select-wrapper">
     {#if "criteria" in element}
-        {#if subgrouping && element.criteria.length > 1}
-            <div part="criterion-section criterion-section-values">
-                <span part="criterion-single-select-name">
-                    alle hinzufügen
-                </span>
-            </div>
-            <button part="query-add-button" on:click={addAll}>
-                {#if $iconStore.get("addIconUrl")}
-                    <img
-                        part="query-add-button-icon"
-                        src={$iconStore.get("addIconUrl")}
-                        alt="add icon"
-                    />
-                {:else}
-                    &#8594;
-                {/if}
-            </button>
-        {/if}
         {#each element.criteria as criterion}
             <SingleSelectItemComponent {element} {criterion} />
         {/each}


### PR DESCRIPTION
### General Summary
Removed a redundant "Add All" button that was visible in some subcategories.

### Description
Dopplung bei Funktion "alle einfügen/add all" bei verschiedenen Gruppen bei UICC-Stadium, TNM-T (siehe Beispiel-Abb.)
![image](https://github.com/user-attachments/assets/8f85c519-712b-4194-831a-93de588496f7)
![image](https://github.com/user-attachments/assets/89591110-bcd8-4f9f-ae1a-df75dd3dae4d)

### Related Issue
Ticket 11 in Confluence

---

### Motivation and Context

### How Has This Been Tested?
This was run in a development environment using `npm start` on MacOs Sonoma 14.5

### Screenshots (if appropriate):
![Screenshot 2024-08-20 at 16 10 58](https://github.com/user-attachments/assets/d0dfcc86-df52-43f3-8962-403da1f243b6)
![Screenshot 2024-08-20 at 16 11 21](https://github.com/user-attachments/assets/42d8e8a4-83d6-459b-8cbb-dea0cddd8a1c)


---

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
