### PR TITLE
feat(options): move catalog response key map

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
 
   spot:
     image: samply/rustyspot:main
+    platform: linux/amd64
     ports:
       - "8055:8055"
     environment:
@@ -93,6 +94,7 @@ services:
 
   beam-proxy:
     image: docker.verbis.dkfz.de/cache/samply/beam-proxy:develop
+    platform: linux/amd64
     environment:
       BROKER_URL: https://${BROKER_HOST}
       PROXY_ID: ${LOCAL_BEAM_ID}.${BROKER_HOST}

--- a/packages/demo/public/options-ccp-demo.json
+++ b/packages/demo/public/options-ccp-demo.json
@@ -24,6 +24,36 @@
         "dktk-test": "DKTK-Test",
         "hamburg": "Hamburg"
     },
+    "catalogueKeyToResponseKeyMap": [
+        [
+            "gender",
+            "Gender"
+        ],
+        [
+            "age_at_diagnosis",
+            "Age"
+        ],
+        [
+            "diagnosis",
+            "diagnosis"
+        ],
+        [
+            "medicationStatements",
+            "MedicationType"
+        ],
+        [
+            "sample_kind",
+            "sample_kind"
+        ],
+        [
+            "therapy_of_tumor",
+            "ProcedureType"
+        ],
+        [
+            "75186-7",
+            "75186-7"
+        ]
+    ],
     "chartOptions": {
         "patients": {
             "legendMapping": {

--- a/packages/demo/public/options-ccp-demo.json
+++ b/packages/demo/public/options-ccp-demo.json
@@ -267,36 +267,6 @@
                     "wuerzburg",
                     "mannheim",
                     "hamburg"
-                ],
-                "catalogueKeyToResponseKeyMap": [
-                    [
-                        "gender",
-                        "Gender"
-                    ],
-                    [
-                        "age_at_diagnosis",
-                        "Age"
-                    ],
-                    [
-                        "diagnosis",
-                        "diagnosis"
-                    ],
-                    [
-                        "medicationStatements",
-                        "MedicationType"
-                    ],
-                    [
-                        "sample_kind",
-                        "sample_kind"
-                    ],
-                    [
-                        "therapy_of_tumor",
-                        "ProcedureType"
-                    ],
-                    [
-                        "75186-7",
-                        "75186-7"
-                    ]
                 ]
             }
         ]

--- a/packages/demo/public/options-ccp-prod.json
+++ b/packages/demo/public/options-ccp-prod.json
@@ -25,6 +25,36 @@
         "dktk-test": "DKTK-Test",
         "hamburg": "Hamburg"
     },
+    "catalogueKeyToResponseKeyMap": [
+        [
+            "gender",
+            "Gender"
+        ],
+        [
+            "age_at_diagnosis",
+            "Age"
+        ],
+        [
+            "diagnosis",
+            "diagnosis"
+        ],
+        [
+            "medicationStatements",
+            "MedicationType"
+        ],
+        [
+            "sample_kind",
+            "sample_kind"
+        ],
+        [
+            "therapy_of_tumor",
+            "ProcedureType"
+        ],
+        [
+            "75186-7",
+            "75186-7"
+        ]
+    ],
     "chartOptions": {
         "patients": {
             "legendMapping": {

--- a/packages/demo/public/options-ccp-prod.json
+++ b/packages/demo/public/options-ccp-prod.json
@@ -262,36 +262,6 @@
                     "wuerzburg",
                     "mannheim",
                     "hamburg"
-                ],
-                "catalogueKeyToResponseKeyMap": [
-                    [
-                        "gender",
-                        "Gender"
-                    ],
-                    [
-                        "age_at_diagnosis",
-                        "Age"
-                    ],
-                    [
-                        "diagnosis",
-                        "diagnosis"
-                    ],
-                    [
-                        "medicationStatements",
-                        "MedicationType"
-                    ],
-                    [
-                        "sample_kind",
-                        "sample_kind"
-                    ],
-                    [
-                        "therapy_of_tumor",
-                        "ProcedureType"
-                    ],
-                    [
-                        "75186-7",
-                        "75186-7"
-                    ]
                 ]
             }
         ]

--- a/packages/demo/public/options-dev.json
+++ b/packages/demo/public/options-dev.json
@@ -23,6 +23,36 @@
         "dktk-test": "DKTK-Test",
         "hamburg": "Hamburg"
     },
+    "catalogueKeyToResponseKeyMap": [
+        [
+            "gender",
+            "Gender"
+        ],
+        [
+            "age_at_diagnosis",
+            "Age"
+        ],
+        [
+            "diagnosis",
+            "diagnosis"
+        ],
+        [
+            "medicationStatements",
+            "MedicationType"
+        ],
+        [
+            "sample_kind",
+            "sample_kind"
+        ],
+        [
+            "therapy_of_tumor",
+            "ProcedureType"
+        ],
+        [
+            "75186-7",
+            "75186-7"
+        ]
+    ],
     "chartOptions": {
         "patients": {
             "legendMapping": {
@@ -149,7 +179,7 @@
                 "rna": "RNA",
                 "derivative-other": "Derivat, Andere"
             },
-            "legendMapping":{
+            "legendMapping": {
                 "ffpe-tissue": "Gewebe FFPE",
                 "frozen-tissue": "Gewebe schockgefroren",
                 "tissue-other": "Gewebe, Andere Konservierungsart",
@@ -239,36 +269,6 @@
                     "wuerzburg",
                     "mannheim",
                     "hamburg"
-                ],
-                "catalogueKeyToResponseKeyMap": [
-                    [
-                        "gender",
-                        "Gender"
-                    ],
-                    [
-                        "age_at_diagnosis",
-                        "Age"
-                    ],
-                    [
-                        "diagnosis",
-                        "diagnosis"
-                    ],
-                    [
-                        "medicationStatements",
-                        "MedicationType"
-                    ],
-                    [
-                        "sample_kind",
-                        "sample_kind"
-                    ],
-                    [
-                        "therapy_of_tumor",
-                        "ProcedureType"
-                    ],
-                    [
-                        "75186-7",
-                        "75186-7"
-                    ]
                 ]
             }
         ],
@@ -276,37 +276,7 @@
             {
                 "name": "DKTK",
                 "backendMeasures": "DKTK_STRAT_DEF_IN_INITIAL_POPULATION",
-                "url": "http://localhost:8080",
-                "catalogueKeyToResponseKeyMap": [
-                    [
-                        "gender",
-                        "Gender"
-                    ],
-                    [
-                        "age_at_diagnosis",
-                        "Age"
-                    ],
-                    [
-                        "diagnosis",
-                        "diagnosis"
-                    ],
-                    [
-                        "medicationStatements",
-                        "MedicationType"
-                    ],
-                    [
-                        "sample_kind",
-                        "sample_kind"
-                    ],
-                    [
-                        "therapy_of_tumor",
-                        "ProcedureType"
-                    ],
-                    [
-                        "75186-7",
-                        "75186-7"
-                    ]
-                ]
+                "url": "http://localhost:8080"
             }
         ]
     }

--- a/packages/lib/src/components/Options.wc.svelte
+++ b/packages/lib/src/components/Options.wc.svelte
@@ -128,10 +128,8 @@
 
     $: catalogueKeyToResponseKeyMap.update((mappings) => {
         if (!options?.catalogueKeyToResponseKeyMap) return mappings;
-        console.log(options.catalogueKeyToResponseKeyMap);
 
         options.catalogueKeyToResponseKeyMap.forEach((mapping) => {
-            console.log(mapping);
             mappings.set(mapping[0], mapping[1]);
         });
         return mappings;

--- a/packages/lib/src/components/Options.wc.svelte
+++ b/packages/lib/src/components/Options.wc.svelte
@@ -23,7 +23,10 @@
     import catalogueSchema from "../types/catalogue.schema.json";
     import { parser } from "@exodus/schemasafe";
     import type { LensOptions } from "../types/options";
-    import { uiSiteMappingsStore } from "../stores/mappings";
+    import {
+        catalogueKeyToResponseKeyMap,
+        uiSiteMappingsStore,
+    } from "../stores/mappings";
 
     export let options: LensOptions = {};
     export let catalogueData: Criteria[] = [];
@@ -120,6 +123,17 @@
             mappings.set(site[0], site[1]);
         });
 
+        return mappings;
+    });
+
+    $: catalogueKeyToResponseKeyMap.update((mappings) => {
+        if (!options?.catalogueKeyToResponseKeyMap) return mappings;
+        console.log(options.catalogueKeyToResponseKeyMap);
+
+        options.catalogueKeyToResponseKeyMap.forEach((mapping) => {
+            console.log(mapping);
+            mappings.set(mapping[0], mapping[1]);
+        });
         return mappings;
     });
 

--- a/packages/lib/src/components/buttons/SearchButtonComponenet.wc.svelte
+++ b/packages/lib/src/components/buttons/SearchButtonComponenet.wc.svelte
@@ -17,17 +17,16 @@
     import { buildLibrary, buildMeasure } from "../../helpers/cql-measure";
     import { Spot } from "../../classes/spot";
     import { Blaze } from "../../classes/blaze";
-    import { catalogueKeyToResponseKeyMap } from "../../stores/mappings";
     import { responseStore, updateResponseStore } from "../../stores/response";
     import { lensOptions } from "../../stores/options";
     import type {
         BackendOptions,
-        BlazeOption,
         Measure,
         MeasureItem,
         MeasureOption,
-        SpotOption,
     } from "../../types/backend";
+    import type { BlazeOption } from "../../types/blaze";
+    import type { SpotOption } from "../../types/spot";
     import type { AstTopLayer } from "../../types/ast";
     import type { Site } from "../../types/response";
 
@@ -38,20 +37,6 @@
     $: options = $lensOptions?.backends as BackendOptions;
 
     let controller: AbortController = new AbortController();
-
-    $: catalogueKeyToResponseKeyMap.update((mappings) => {
-        options?.spots?.forEach((spot) => {
-            spot.catalogueKeyToResponseKeyMap.forEach((mapping) => {
-                mappings.set(mapping[0], mapping[1]);
-            });
-        });
-        options?.blazes?.forEach((blaze: BlazeOption) => {
-            blaze.catalogueKeyToResponseKeyMap.forEach((mapping) => {
-                mappings.set(mapping[0], mapping[1]);
-            });
-        });
-        return mappings;
-    });
 
     /**
      * Triggers a request to the backend.

--- a/packages/lib/src/types/options.schema.json
+++ b/packages/lib/src/types/options.schema.json
@@ -47,6 +47,17 @@
             "unevaluatedProperties": false,
             "required": []
         },
+        "catalogueKeyToResponseKeyMap": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "pattern": "^.+$",
+                    "description": "The mapping of the catalogue key to the response key"
+                }
+            }
+        },
         "chartOptions": {
             "type": "object",
             "patternProperties": {
@@ -286,17 +297,6 @@
                                     "pattern": "^.+$",
                                     "description": "The sites of the spot"
                                 }
-                            },
-                            "catalogueKeyToResponseKeyMap": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "pattern": "^.+$",
-                                        "description": "The mapping of the catalogue key to the response key"
-                                    }
-                                }
                             }
                         },
                         "additionalProperties": false,
@@ -323,17 +323,6 @@
                                 "type": "string",
                                 "pattern": "^.+$",
                                 "description": "The URL of the blaze"
-                            },
-                            "catalogueKeyToResponseKeyMap": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "pattern": "^.+$",
-                                        "description": "The mapping of the catalogue key to the response key"
-                                    }
-                                }
                             }
                         },
                         "additionalProperties": false,

--- a/packages/lib/src/types/options.ts
+++ b/packages/lib/src/types/options.ts
@@ -1,6 +1,7 @@
 export type LensOptions = {
     [key: string]: unknown;
     chartOptions?: ChartOptions;
+    catalogueKeyToResponseKeyMap?: string[][];
 };
 
 export type ChartOptions = {


### PR DESCRIPTION
### General Summary
Moved the catalogue to response key map up in main structure.

### Description
The map was part of the spot/blaze-options which lead to custom backends not be able to insert their map

### Related Issue
-

---

### How Has This Been Tested?
Chrome


### Screenshots (if appropriate):

---

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
