### PR TITLE
fix: added missing date option in fieldType enum of catalogue schema

### DIFF
--- a/packages/lib/src/types/catalogue.schema.json
+++ b/packages/lib/src/types/catalogue.schema.json
@@ -44,7 +44,8 @@
                     "enum": [
                         "single-select",
                         "number",
-                        "autocomplete"
+                        "autocomplete",
+                        "date"
                     ]
                 },
                 "type": {


### PR DESCRIPTION
### General Summary

### Description
Added missing date option in fieldType enum of catalogue JSON schema