### PR TITLE
Implemented re-import of the Ast

### DIFF
--- a/packages/lib/src/components/DataPasser.wc.svelte
+++ b/packages/lib/src/components/DataPasser.wc.svelte
@@ -86,7 +86,7 @@
      * sets the query store using the ast representation of a query
      * @param ast the ast that should be imported
      */
-    export const setQueryStoreWithAstAPI = (ast: AstTopLayer): void => {
+    export const setQueryStoreFromAstAPI = (ast: AstTopLayer): void => {
         let query = buildQueryFromAst(ast);
         queryStore.set(query);
     };

--- a/packages/lib/src/components/DataPasser.wc.svelte
+++ b/packages/lib/src/components/DataPasser.wc.svelte
@@ -23,6 +23,7 @@
         RemoveItemFromQuyeryAPIParams,
         RemoveValueFromQueryAPIParams,
     } from "../types/dataPasser";
+    import { buildQueryFromAst } from "../helpers/ast-transformer.ts";
 
     /**
      * Getters
@@ -79,6 +80,15 @@
      */
     export const setQueryStoreAPI = (newQuery: QueryItem[][]): void => {
         queryStore.set(newQuery);
+    };
+
+    /**
+     * sets the query store using the ast representation of a query
+     * @param ast the ast that should be imported
+     */
+    export const setQueryStoreWithAstAPI = (ast: AstTopLayer): void => {
+        let query = buildQueryFromAst(ast);
+        queryStore.set(query);
     };
 
     /**

--- a/packages/lib/src/helpers/ast-transformer.ts
+++ b/packages/lib/src/helpers/ast-transformer.ts
@@ -1,5 +1,19 @@
-import type { AstElement, AstTopLayer } from "../types/ast";
-import type { QueryItem, queryStoreItem } from "../types/queryData";
+import { v4 as uuidv4 } from "uuid";
+import {
+    isTopLayer,
+    type AstElement,
+    type AstTopLayer,
+    isBottomLayer,
+    type AstBottomLayerValue,
+} from "../types/ast";
+import type { QueryItem, QueryValue, queryStoreItem } from "../types/queryData";
+import type { AggregatedValue } from "../../../../dist/types";
+import {
+    catalogue,
+    getCategoryFromKey,
+    getCriteriaFromKey,
+} from "../stores/catalogue";
+import { get } from "svelte/store";
 
 /**
  * builds an AST from the query store
@@ -11,12 +25,204 @@ export const buildAstFromQuery = (queryStore: QueryItem[][]): AstTopLayer => {
 
     if (ast.children.length === 1 && ast.children[0] === null) {
         return {
+            key: "",
             operand: "OR",
             children: [],
         };
     }
 
     return ast;
+};
+
+/**
+ * build a query store from an AST
+ * @param ast - the AST to transform
+ * @returns query
+ */
+export const buildQueryFromAst = (ast: AstTopLayer): QueryItem[][] => {
+    return divideQueries(ast);
+};
+
+/**
+ * split the top level ast into the multiple OR connected queries
+ * @param queries - the whole AST to transform
+ * @returns array of different queries
+ */
+const divideQueries = (queries: AstTopLayer): QueryItem[][] => {
+    return queries.children.map((child) => divideCriterias(child));
+};
+
+/**
+ * divide a query into all different criteria
+ * NOTE: at the moment we don't expect a AstBottomLayer here, because we always have a logical AND between the criterias of a query
+ * @param query - a single query consiting of multiple criteria
+ * @returns a single query in the internal representation
+ */
+const divideCriterias = (query: AstElement): QueryItem[] => {
+    if (isTopLayer(query)) {
+        const criterias = query.children
+            .filter((child) => isTopLayer(child))
+            .map((child) => convertCriteria(<AstTopLayer>child));
+        return criterias != undefined ? <QueryItem[]>criterias : [];
+    } else {
+        return [];
+    }
+};
+
+/**
+ * convert a query criteria to it's internal query item representation
+ * NOTE: we have two cases here: 1) normal criteria represented as AstBottomLayerValue 2) complex criteria represented as an AstTopLayer
+ * @param criteria - a single query criteria
+ * @returns the internal QueryItem representation of this criteria
+ */
+const convertCriteria = (criteria: AstTopLayer): QueryItem | undefined => {
+    const values = criteria.children.filter((child) => isBottomLayer(child));
+    if (values.length === 0) return convertComplexCriteria(criteria);
+    const checkedValues: AstBottomLayerValue[] = <AstBottomLayerValue[]>values;
+    const convertedValues = convertValues(checkedValues);
+    const catalogueCategory = getCategoryFromKey(
+        get(catalogue),
+        checkedValues[0].key,
+    );
+    const convertedCriteria: QueryItem = {
+        id: uuidv4(),
+        key: checkedValues[0].key,
+        name: catalogueCategory != undefined ? catalogueCategory.name : "",
+        type: checkedValues[0].type,
+        system: checkedValues[0].system,
+        values: convertedValues,
+    };
+    if (catalogueCategory != undefined && "description" in catalogueCategory) {
+        convertedCriteria.description = catalogueCategory.description;
+    }
+    return convertedCriteria;
+};
+
+/**
+ * convert a query criteria based on an AstTopLayer to it's internal representation
+ * @param criteria - an AstTopLayer based criteria
+ * @returns the internal QueryItem representation of this criteria
+ */
+const convertComplexCriteria = (criteria: AstTopLayer): QueryItem => {
+    const values = criteria.children.filter((child) => isTopLayer(child));
+    const checkedValues: AstTopLayer[] = <AstTopLayer[]>values;
+    const convertedValues = convertValues(checkedValues);
+    const criteriaCateogory = getCategoryFromKey(get(catalogue), criteria.key);
+    return {
+        id: uuidv4(),
+        key: criteria.key,
+        name: criteriaCateogory != undefined ? criteriaCateogory.name : "",
+        // NOTE: Assuming hard coding here, proof me wrong
+        type: "EQUALS",
+        description:
+            criteriaCateogory != undefined && "description" in criteriaCateogory
+                ? criteriaCateogory.description
+                : "",
+        system: "",
+        values: convertedValues,
+    };
+};
+
+const convertValues = (values: AstElement[]): QueryValue[] => {
+    return values.map((value) => convertValue(value));
+};
+
+const convertValue = (value: AstElement): QueryValue => {
+    if (isBottomLayer(value)) {
+        return convertBottomLayerValue(value);
+    } else {
+        return convertTopLayerValue(value);
+    }
+};
+
+/**
+ * converts the values of an AstTopLayer criteria
+ * @param value - the AstTopLayer
+ * @returns a QueryValue
+ */
+const convertTopLayerValue = (value: AstTopLayer): QueryValue => {
+    const values = value.children
+        .map((orArray) => {
+            if (isTopLayer(orArray)) {
+                const result = orArray.children.map((andValue) => {
+                    if (isBottomLayer(andValue)) {
+                        return {
+                            name: andValue.key,
+                            value: andValue.value.toString(),
+                        };
+                    }
+                });
+                const filteredResult = result.filter(
+                    (value) => value !== undefined,
+                );
+                return <AggregatedValue[]>filteredResult;
+            }
+        })
+        .filter((value) => value != undefined);
+    return {
+        queryBindId: uuidv4(),
+        name: value.key,
+        value: <AggregatedValue[][]>values,
+    };
+};
+
+/**
+ * converts the values of an AstBottomLayerValue criteria
+ * @param value - the AstBottomLayerValue
+ * @returns a QueryValue
+ */
+const convertBottomLayerValue = (value: AstBottomLayerValue): QueryValue => {
+    let mappedName: string = `Combination ${value.key} and ${value.value} is not mapped!`;
+    let mappedValue:
+        | string
+        | { min: number; max: number }
+        | AggregatedValue[][] =
+        "WARNING: This value was not processed by convertValue function!";
+
+    if (typeof value.value === "string") {
+        const criteria = getCriteriaFromKey(
+            get(catalogue),
+            value.key,
+            value.value,
+        );
+        mappedName = criteria != undefined ? criteria.name : "";
+        mappedValue = value.value;
+    } else if (typeof value.value === "boolean") {
+        mappedValue = value.value.toString();
+    } else if (typeof value.value === "object") {
+        if ("min" in value.value && "max" in value.value) {
+            mappedName =
+                value.value.min === 0
+                    ? ` ≤ ${value.value.max}`
+                    : value.value.max === 0
+                      ? ` ≥ ${value.value.min}`
+                      : ` ${value.value.min} - ${value.value.max}`;
+            if (
+                typeof value.value.min === "number" &&
+                typeof value.value.max === "number"
+            ) {
+                mappedValue = { min: value.value.min, max: value.value.max };
+            } else if (
+                typeof value.value.min === "string" &&
+                typeof value.value.max === "string"
+            ) {
+                const minDate = new Date(value.value.min);
+                const maxDate = new Date(value.value.min);
+                mappedValue = {
+                    min: minDate.getDate(),
+                    max: maxDate.getDate(),
+                };
+            }
+        } else {
+            mappedValue =
+                "TODO: This is the not mapped Array<string> case for value";
+        }
+    }
+    return {
+        queryBindId: uuidv4(),
+        name: mappedName,
+        value: mappedValue,
+    };
 };
 
 /**
@@ -62,6 +268,7 @@ export const returnNestedValues = (
      */
     if ("values" in item && Array.isArray(item.values)) {
         return {
+            key: item.key,
             operand: operand,
             children: item.values.map((value) => {
                 return returnNestedValues(value, operand, item);
@@ -74,6 +281,7 @@ export const returnNestedValues = (
      */
     if ("value" in item && Array.isArray(item.value)) {
         return {
+            key: item.name,
             operand: operand,
             children: item.value.map((value) => {
                 return returnNestedValues(value, operand, item);

--- a/packages/lib/src/helpers/ast-transformer.ts
+++ b/packages/lib/src/helpers/ast-transformer.ts
@@ -25,7 +25,6 @@ export const buildAstFromQuery = (queryStore: QueryItem[][]): AstTopLayer => {
 
     if (ast.children.length === 1 && ast.children[0] === null) {
         return {
-            key: "",
             operand: "OR",
             children: [],
         };

--- a/packages/lib/src/stores/catalogue.ts
+++ b/packages/lib/src/stores/catalogue.ts
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-import type { Category, TreeNode } from "../types/treeData";
+import type { Category, Criteria, TreeNode } from "../types/treeData";
 
 /**
  * store to hold the catalogue
@@ -141,4 +141,51 @@ export const getCriteriaNamesFromKey = (
         criteriaNames = ["20", "30", "40", "50"];
     }
     return criteriaNames;
+};
+
+export const getCategoryFromKey = (
+    catalogue: Category[],
+    key: string,
+): Category | undefined => {
+    let category: Category | undefined = undefined;
+
+    if (catalogue.length === 0 || key === "") {
+        return category;
+    }
+
+    catalogue.forEach((catalogueEntry: Category) => {
+        if ("childCategories" in catalogueEntry) {
+            if (catalogueEntry.childCategories != undefined) {
+                const result = getCategoryFromKey(
+                    catalogueEntry.childCategories,
+                    key,
+                );
+                if (result != undefined) category = result;
+            }
+        } else {
+            if (catalogueEntry.key === key) {
+                category = catalogueEntry;
+            }
+        }
+    });
+
+    return category;
+};
+
+export const getCriteriaFromKey = (
+    catalogue: Category[],
+    categoryKey: string,
+    criteriaKey: string,
+): Criteria | undefined => {
+    const category: Category | undefined = getCategoryFromKey(
+        catalogue,
+        categoryKey,
+    );
+    if (category == undefined) return undefined;
+    if ("criteria" in category) {
+        return category.criteria.find(
+            (criteria) => criteria.key === criteriaKey,
+        );
+    }
+    return undefined;
 };

--- a/packages/lib/src/types/ast.ts
+++ b/packages/lib/src/types/ast.ts
@@ -1,6 +1,10 @@
 export type AstElement = AstTopLayer | AstBottomLayerValue;
+export const isTopLayer = (x: AstElement): x is AstTopLayer => "operand" in x;
+export const isBottomLayer = (x: AstElement): x is AstBottomLayerValue =>
+    "value" in x;
 
 export type AstTopLayer = {
+    key: string;
     operand: "AND" | "OR";
     children: AstElement[];
 };

--- a/packages/lib/src/types/ast.ts
+++ b/packages/lib/src/types/ast.ts
@@ -4,7 +4,7 @@ export const isBottomLayer = (x: AstElement): x is AstBottomLayerValue =>
     "value" in x;
 
 export type AstTopLayer = {
-    key: string;
+    key?: string;
     operand: "AND" | "OR";
     children: AstElement[];
 };

--- a/packages/lib/src/types/dataPasser.ts
+++ b/packages/lib/src/types/dataPasser.ts
@@ -30,4 +30,5 @@ export interface LensDataPasser extends HTMLElement {
     removeValueFromQueryAPI(params: RemoveValueFromQueryAPIParams): void;
     updateResponseAPI(params: ResponseStore): void;
     setQueryStoreAPI(params: QueryItem[][]): void;
+    setQueryStoreFromAstAPI(params: QueryItem[][]): void;
 }


### PR DESCRIPTION
### General Summary

In the first implementation of lens it was possible to re-import an AST back into lens. With this implementation, the same will be possible in this implementation.
The new implementation is currently in one point inferior to the old implementation. With the old implementation, the main id of the query didn't change upon import. This caveat is currently caused by the ast not containing the query id. This topic should be clarified before the merge.

---

### How Has This Been Tested?
Currently by locally comparing a query before transforming it to ast with after the import of that same query

---

- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [x] Documentation has been added/ updated
