### PR TITLE
feat: add the option to show user-facing errors as toasts

### DIFF
--- a/packages/demo/src/AppCCP.svelte
+++ b/packages/demo/src/AppCCP.svelte
@@ -296,6 +296,9 @@
     >
 </footer>
 
+<!-- Toasts use `position: fixed` and thus are removed from the normal document flow -->
+<error-toasts />
+
 {#await jsonPromises}
     Loading data...
 {:then { optionsJSON, catalogueJSON }}

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -11,5 +11,6 @@ export { default as InfoButton } from "./src/components/buttons/InfoButtonCompon
 export { default as lensOptions } from "./src/components/Options.wc.svelte";
 export { default as DataPasser } from "./src/components/DataPasser.wc.svelte";
 export { default as ModifiedSearchComponent } from "./src/components/informational/ModifiedSearchComponent.wc.svelte";
+export { default as ErrorToasts } from "./src/components/ErrorToasts.wc.svelte";
 
 export * from "./src/styles/index.css?inline";

--- a/packages/lib/src/classes/spot.ts
+++ b/packages/lib/src/classes/spot.ts
@@ -99,7 +99,7 @@ export class Spot {
             } else {
                 console.error(err);
                 // show user-facing error
-                errorChannel.set(`Fehler beim Bearbeiten der Anfrage: ${err}`);
+                errorChannel.set("Fehler beim Bearbeiten der Anfrage");
             }
         }
     }

--- a/packages/lib/src/classes/spot.ts
+++ b/packages/lib/src/classes/spot.ts
@@ -5,6 +5,7 @@
 import type { SiteData, Status } from "../types/response";
 import type { ResponseStore } from "../types/backend";
 import type { BeamResult } from "../types/spot";
+import { errorChannel } from "../stores/error-channel";
 
 export class Spot {
     private currentTask!: string;
@@ -97,6 +98,8 @@ export class Spot {
                 console.log(`Aborting request ${this.currentTask}`);
             } else {
                 console.error(err);
+                // show user-facing error
+                errorChannel.set(`Fehler beim Bearbeiten der Anfrage: ${err}`);
             }
         }
     }

--- a/packages/lib/src/components/ErrorToasts.wc.svelte
+++ b/packages/lib/src/components/ErrorToasts.wc.svelte
@@ -1,0 +1,36 @@
+<svelte:options
+    customElement={{
+        tag: "error-toasts",
+    }}
+/>
+
+<script lang="ts">
+    import { errorChannel } from "../stores/error-channel";
+
+    let toasts = [];
+
+    /**
+     * @param message user-facing error message
+     */
+    function showToast(message: string): void {
+        toasts.push(message);
+        toasts = toasts; // update
+
+        setTimeout(() => {
+            toasts.shift();
+            toasts = toasts; // update
+        }, 8000);
+    }
+
+    // subscribe to error channel
+    $: if ($errorChannel) {
+        showToast($errorChannel);
+        errorChannel.set(null);
+    }
+</script>
+
+<div part="flex-container">
+    {#each toasts as toast}
+        <div part="toast">{toast}</div>
+    {/each}
+</div>

--- a/packages/lib/src/components/ErrorToasts.wc.svelte
+++ b/packages/lib/src/components/ErrorToasts.wc.svelte
@@ -5,15 +5,16 @@
 />
 
 <script lang="ts">
+    import { fade } from "svelte/transition";
     import { errorChannel } from "../stores/error-channel";
 
-    let toasts = [];
+    let toasts: { uuid: string; message: string }[] = [];
 
     /**
      * @param message user-facing error message
      */
     function showToast(message: string): void {
-        toasts.push(message);
+        toasts.push({ uuid: crypto.randomUUID(), message });
         toasts = toasts; // update
 
         setTimeout(() => {
@@ -25,12 +26,12 @@
     // subscribe to error channel
     $: if ($errorChannel) {
         showToast($errorChannel);
-        errorChannel.set(null);
+        errorChannel.set("");
     }
 </script>
 
 <div part="flex-container">
-    {#each toasts as toast}
-        <div part="toast">{toast}</div>
+    {#each toasts as toast (toast.uuid)}
+        <div out:fade part="toast">{toast.message}</div>
     {/each}
 </div>

--- a/packages/lib/src/stores/error-channel.ts
+++ b/packages/lib/src/stores/error-channel.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 /**
  * This channel is intended for user-facing error messages. You can write a
  * custom component that consumes the channel or use the <error-toasts />
- * component.
+ * component to render errors as toasts.
  * @example
  * // write to the channel
  * errorChannel.set('Something went wrong.');

--- a/packages/lib/src/stores/error-channel.ts
+++ b/packages/lib/src/stores/error-channel.ts
@@ -1,0 +1,11 @@
+import { writable } from "svelte/store";
+
+/**
+ * This channel is intended for user-facing error messages. You can write a
+ * custom component that consumes the channel or use the <error-toasts />
+ * component.
+ * @example
+ * // write to the channel
+ * errorChannel.set('Something went wrong.');
+ */
+export const errorChannel = writable("");

--- a/packages/lib/src/styles/error-toasts.css
+++ b/packages/lib/src/styles/error-toasts.css
@@ -1,0 +1,17 @@
+error-toasts::part(flex-container) {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    padding: var(--gap-s);
+}
+
+error-toasts::part(toast) {
+    border-radius: var(--border-radius-small);
+    background-color: var(--light-orange);
+    border: solid 1px var(--red);
+    padding: var(--gap-xs);
+}

--- a/packages/lib/src/styles/error-toasts.css
+++ b/packages/lib/src/styles/error-toasts.css
@@ -11,7 +11,7 @@ error-toasts::part(flex-container) {
 
 error-toasts::part(toast) {
     border-radius: var(--border-radius-small);
-    background-color: var(--light-orange);
+    background-color: #EF9A9A;
     border: solid 1px var(--red);
     padding: var(--gap-xs);
 }

--- a/packages/lib/src/styles/index.css
+++ b/packages/lib/src/styles/index.css
@@ -6,7 +6,7 @@
 @import url('./result-chart.css');
 @import url('./negotiate-button.css');
 @import url('./info-button.css');
-
+@import url('./error-toasts.css');
 
 :root {
     --white: #ffffff;


### PR DESCRIPTION
This PR adds the channel `errorChannel` for user-facing error messages. Lens core and applications that use lens core can write to the channel. Applications that use lens core can consume the channel from a custom component or use the provided `<error-toasts />` component to render messages as toasts:

![image](https://github.com/user-attachments/assets/2e0bfbfb-e870-476f-9ec8-a895814b6fac)

Currently only `spot.ts` writes to `errorChannel` - this can be tested by clicking the "Suchen" button in the demo. Before further extending this I wanted to check if you agree with the general approach.

A potential issue is that user-facing messages require localization. For now I've written the error message in `spot.ts` in German, but I suppose not all applications that use lens core are in German.

Related issue: #74

---

<!--- Please check if the PR fulfills these requirements -->
- [x] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
