### PR TITLE
feat: added info link for catalogue catagories

### DIFF
--- a/packages/demo/public/catalogues/catalogue-dktk-staging.json
+++ b/packages/demo/public/catalogues/catalogue-dktk-staging.json
@@ -20359,6 +20359,10 @@
         "key": "project",
         "name": "Forschungsprojekte",
         "infoButtonText": ["Projekt-Übersicht"],
+        "infoLink": {
+            "link": "https://hub.dkfz.de/s/EZTqXGcx7mWWapr",
+            "display": "↗Projekt-Übersicht"
+        },
         "childCategories": [
             {
                 "key": "pseudo_projects",

--- a/packages/lib/src/components/catalogue/DataTreeElement.svelte
+++ b/packages/lib/src/components/catalogue/DataTreeElement.svelte
@@ -155,6 +155,12 @@
         <InfoButtonComponent message={element.infoButtonText} />
     {/if}
 
+    {#if element.infoLink}
+        <a href={element.infoLink.link} target="_blank"
+            >{element.infoLink.display}</a
+        >
+    {/if}
+
     {#if finalParent && open}
         <button part="add-all-options-button" on:click={selectAllOptions}>
             {selectAllText ? selectAllText : "Add all"}

--- a/packages/lib/src/types/catalogue.schema.json
+++ b/packages/lib/src/types/catalogue.schema.json
@@ -36,6 +36,25 @@
                         "pattern": "^.*$"
                     }
                 },
+                "infoLink": {
+                    "type": "object",
+                    "properties": {
+                        "link": {
+                            "type": "string",
+                            "pattern": "^.+$"
+                        },
+                        "display": {
+                            "type": "string",
+                            "pattern": "^.+$"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "unevaluatedProperties": false,
+                    "required": [
+                        "link",
+                        "display"
+                    ]
+                },
                 "system": {
                     "type": "string",
                     "pattern": "^.*$"

--- a/packages/lib/src/types/treeData.ts
+++ b/packages/lib/src/types/treeData.ts
@@ -11,6 +11,12 @@ export type CategoryNode = {
     childCategories?: Category[];
     infoButtonText?: string[];
     subCategoryName?: string;
+    extra?: CategoryExtra;
+};
+
+export type CategoryExtra = {
+    link?: string;
+    display?: string;
 };
 
 export type CatagoryLeaf = {

--- a/packages/lib/src/types/treeData.ts
+++ b/packages/lib/src/types/treeData.ts
@@ -11,12 +11,12 @@ export type CategoryNode = {
     childCategories?: Category[];
     infoButtonText?: string[];
     subCategoryName?: string;
-    extra?: CategoryExtra;
+    infoLink?: InfoLink;
 };
 
-export type CategoryExtra = {
-    link?: string;
-    display?: string;
+export type InfoLink = {
+    link: string;
+    display: string;
 };
 
 export type CatagoryLeaf = {


### PR DESCRIPTION
### General Summary

### Description
We need the possibility to add link to certain catalogue entries. This PR added infoLink as new add option and generated the link beside the info button.

