### PR TITLE
fix: clear search bar input when it loses focus

### DIFF
--- a/packages/lib/src/components/search-bar/SearchBarComponent.wc.svelte
+++ b/packages/lib/src/components/search-bar/SearchBarComponent.wc.svelte
@@ -405,6 +405,7 @@
         }}
         on:focusout={() => {
             autoCompleteOpen = false;
+            inputValue = "";
         }}
     />
     {#if autoCompleteOpen && inputValue.length > 2}


### PR DESCRIPTION
I made it such that when the free text input of the search bar loses focus the text is cleared. This feels most natural to me.

Fixes #175 