### PR TITLE
Chore/fix vite warning

### DIFF
--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -13,4 +13,4 @@ export { default as DataPasser } from "./src/components/DataPasser.wc.svelte";
 export { default as ModifiedSearchComponent } from "./src/components/informational/ModifiedSearchComponent.wc.svelte";
 export { default as ErrorToasts } from "./src/components/ErrorToasts.wc.svelte";
 
-export * from "./src/styles/index.css";
+import "./src/styles/index.css";


### PR DESCRIPTION
Gets rid of this vite warning:

> Default and named imports from CSS files are deprecated. Use the ?inline query instead. For example: export * from "./src/styles/index.css?inline"