### PR TITLE
fix: don't show beam error to user

### DIFF
--- a/packages/lib/src/classes/spot.ts
+++ b/packages/lib/src/classes/spot.ts
@@ -80,13 +80,6 @@ export class Spot {
                 updateResponse(parsedResponse);
             });
 
-            // read error events from beam
-            eventSource.addEventListener("error", (message) => {
-                console.error(`Beam returned error ${message}`);
-                errorChannel.set("Fehler von Beam erhalten"); // show user-facing error
-                eventSource.close();
-            });
-
             // event source in javascript throws an error then the event source is closed by backend
             eventSource.onerror = () => {
                 console.info(


### PR DESCRIPTION
We used to show an error to the user when the "error" event of the server sent events source fires. The error message was misleading because it indicated that the error originated from beam, whereas the "error" event only indicates that the server sent events stream was interrupted. When the stream is interrupted the server sent events source tries to reconnect after firing the "error" event. In our case where the server sents events connection is rather short lived (only until we got results from all sites) it makes sense to treat an interruption of the stream as indication that the server closed the connection and not try to reconnect. In fact, there was already a second event handler for the "error" event that did exactly that. So this commit removes the first event handler that shows the error to the user and keeps the second as it was.

Fixes #198