### PR TITLE
chore: restore old structure of the empty query

### DIFF
--- a/packages/lib/src/helpers/ast-transformer.ts
+++ b/packages/lib/src/helpers/ast-transformer.ts
@@ -21,7 +21,28 @@ import { get } from "svelte/store";
  * @returns Ast: the AST will later be converted to a query language of choice
  */
 export const buildAstFromQuery = (queryStore: QueryItem[][]): AstTopLayer => {
-    return returnNestedValues(queryStore) as AstTopLayer;
+    const ast = returnNestedValues(queryStore) as AstTopLayer;
+
+    // The empty query is currently a special case because focus and potentially other consumers want it like this
+    // Instead of:
+    // {"nodeType":"branch","operand":"OR","children":[{"nodeType":"branch","operand":"AND","children":[]}]}
+    // We return:
+    // {"nodeType":"branch","operand":"OR","children":[]}
+    if (ast.children.length === 1) {
+        const onlyChild = ast.children[0];
+        if (
+            onlyChild.nodeType === "branch" &&
+            onlyChild.children.length === 0
+        ) {
+            return {
+                nodeType: "branch",
+                operand: "OR",
+                children: [],
+            };
+        }
+    }
+
+    return ast;
 };
 
 /**


### PR DESCRIPTION
We had this special case before https://github.com/samply/lens/blob/60bebaa17d840604c282ea161fa42256c2a44a57/packages/lib/src/helpers/ast-transformer.ts#L12-L39

This PR adds it again

Fixes #202