### PR TITLE
Feat/improve chart combine subgroup performance

### DIFF
--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -356,68 +356,47 @@
         responseStore: ResponseStore,
         labels: string[],
     ): { labels: string[]; data: number[] } => {
-        const groupedChartData: { label: string; value: number }[] =
-            labels.reduce<{ label: string; value: number }[]>((acc, label) => {
-                // This is a hack! This will help with the wrong coding of ICD10
-                label = label.replace(/_/g, ".");
+        // console.log(`processing ${labels.length} labels`);
+        // const start = performance.now();
 
-                /**
+        const labelsToData = new Map<string, number>();
+        for (const label of labels) {
+            // This is a hack! This will help with the wrong coding of ICD10
+            // label = label.replace(/_/g, ".");
+
+            const value = getAggregatedPopulationForStratumCode(
+                responseStore,
+                label,
+                responseGroupCode,
+            );
+
+            if (!label.includes(divider) || divider === "") {
+                /*
                  * see if the label contains the divider
-                 * if not, add it to the accumulator with a .% at the end
+                 * if not, add it to the accumulator with a grouping label (.%) at the end
                  */
-                if (!label.includes(divider) || divider === "") {
-                    return [
-                        ...acc,
-                        {
-                            label: label + groupingLabel,
-                            value: getAggregatedPopulationForStratumCode(
-                                responseStore,
-                                label,
-                                responseGroupCode,
-                            ),
-                        },
-                    ];
-                }
-
-                /**
+                labelsToData.set(label + groupingLabel, value);
+            } else {
+                /*
                  * if the label contains the divider, find the corresponding super class item
                  * if it doesn't exist, create it
                  * add the value of the current label to the value of the super class item
-                 * and add it to the accumulator
                  */
-                let superClassItem:
-                    | { label: string; value: number }
-                    | undefined = acc.find(
-                    (item) =>
-                        item.label === label.split(divider)[0] + groupingLabel,
+                const superClassLabel = label.split(divider)[0] + groupingLabel;
+                let oldValue = labelsToData.get(superClassLabel);
+                labelsToData.set(
+                    superClassLabel,
+                    oldValue ? oldValue + value : value,
                 );
+            }
+        }
 
-                if (!superClassItem) {
-                    superClassItem = {
-                        label: label.split(divider)[0] + groupingLabel,
-                        value: 0,
-                    };
-                }
-
-                superClassItem.value += getAggregatedPopulationForStratumCode(
-                    responseStore,
-                    label,
-                    responseGroupCode,
-                );
-
-                return [
-                    ...acc.filter(
-                        (item) =>
-                            item.label !==
-                            label.split(divider)[0] + groupingLabel,
-                    ),
-                    superClassItem,
-                ];
-            }, []);
+        // const end = performance.now();
+        // console.log(`processing took ${end - start} ms`);
 
         return {
-            labels: groupedChartData.map((item) => item.label),
-            data: groupedChartData.map((item) => item.value),
+            labels: Array.from(labelsToData.keys()),
+            data: Array.from(labelsToData.values()),
         };
     };
 

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -356,14 +356,8 @@
         responseStore: ResponseStore,
         labels: string[],
     ): { labels: string[]; data: number[] } => {
-        // console.log(`processing ${labels.length} labels`);
-        // const start = performance.now();
-
         const labelsToData = new Map<string, number>();
         for (const label of labels) {
-            // This is a hack! This will help with the wrong coding of ICD10
-            // label = label.replace(/_/g, ".");
-
             const value = getAggregatedPopulationForStratumCode(
                 responseStore,
                 label,
@@ -390,9 +384,6 @@
                 );
             }
         }
-
-        // const end = performance.now();
-        // console.log(`processing took ${end - start} ms`);
 
         return {
             labels: Array.from(labelsToData.keys()),

--- a/src/stores/response.ts
+++ b/src/stores/response.ts
@@ -113,25 +113,24 @@ export const getSitePopulationForStratumCode = (
     stratumCode: string,
     stratifier: string,
 ): number => {
-    if (!site || !site.group) return 0;
-
-    let population: number = 0;
-
-    site.group.forEach((group) => {
-        group.stratifier.forEach((stratifierItem) => {
-            if (stratifierItem.code[0].text !== stratifier) return;
-            stratifierItem.stratum?.forEach((stratumItem) => {
-                if (
-                    stratumItem.value.text === stratumCode &&
-                    stratumItem.population !== undefined
-                ) {
-                    population = stratumItem.population[0].count;
+    for (const group of site.group) {
+        for (const stratifierItem of group.stratifier) {
+            if (
+                stratifierItem.code[0].text === stratifier &&
+                stratifierItem.stratum !== undefined
+            ) {
+                for (const stratumItem of stratifierItem.stratum) {
+                    if (
+                        stratumItem.value.text === stratumCode &&
+                        stratumItem.population !== undefined
+                    ) {
+                        return stratumItem.population[0].count;
+                    }
                 }
-            });
-        });
-    });
-
-    return population;
+            }
+        }
+    }
+    return 0;
 };
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
             // Only emit ESM, no CommonJS
             formats: ["es"],
         },
+        // Also emit source map as lens.js.map
+        sourcemap: true,
     },
     plugins: [
         svelte(),


### PR DESCRIPTION
`combineSubGroups` in `ChartComponent.wc.svelte` is the reason why BBMRI Sample Locator is unresponsive while search results are coming in. This PR improves the performance a little bit which roughly halves the time the UI is blocked. Although the real fix would be to change the `SiteData` type to allow efficient lookups of stratifier and stratum without searching through everything.

I've also added a source map to the lens package which makes debugging these kind of issues easier with the Chrome Dev Tools.