### PR TITLE
chore: use uuidv4() instead of crypto.randomUUID()

### DIFF
--- a/src/classes/spot.ts
+++ b/src/classes/spot.ts
@@ -6,6 +6,7 @@ import type { SiteData } from "../types/response";
 import type { ResponseStore } from "../types/backend";
 import type { BeamResult } from "../types/spot";
 import { showError } from "../stores/toasts";
+import { v4 as uuidv4 } from "uuid";
 
 export class Spot {
     private currentTask!: string;
@@ -27,7 +28,7 @@ export class Spot {
         controller: AbortController,
     ): Promise<void> {
         try {
-            this.currentTask = crypto.randomUUID();
+            this.currentTask = uuidv4();
             const beamTaskResponse = await fetch(
                 `${this.url}beam?sites=${this.sites.toString()}`,
                 {


### PR DESCRIPTION
crypto.randomUUID only works in secure contexts which can be an annoyance when testing