### PR TITLE
chore: get rid of svelte/legacy imports

### DIFF
--- a/src/components/catalogue/AutoCompleteComponent.svelte
+++ b/src/components/catalogue/AutoCompleteComponent.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { run } from "svelte/legacy";
-
     import type { AutocompleteCategory, Criteria } from "../../types/catalogue";
     import { v4 as uuidv4 } from "uuid";
     import {
@@ -55,11 +53,6 @@
 
         criteria = criteria.concat(subgroups);
     });
-
-    /**
-     * stores the filtered list of autocomplete items
-     */
-    let inputOptions: Criteria[] = $state([]);
 
     /**
      * input element binds to this variable. Used to focus the input element
@@ -236,11 +229,12 @@
         );
         return resultString;
     };
+
     /**
-     * watches the input value and updates the input options
+     * stores the filtered list of autocomplete items
      */
-    run(() => {
-        inputOptions = criteria.filter((item: Criteria) => {
+    let inputOptions: Criteria[] = $derived.by(() => {
+        return criteria.filter((item: Criteria) => {
             const clearedInputValue = inputValue
                 .replace(/^[0-9]*:/g, "")
                 .toLocaleLowerCase();
@@ -258,6 +252,7 @@
             );
         });
     });
+
     /**
      * list of options that allready have been chosen and should be displayed beneath the autocomplete input
      * chosenOptions are constructed from the query store and has no duplicates
@@ -277,7 +272,8 @@
             [],
         ),
     );
-    run(() => {
+
+    $effect(() => {
         if (activeDomElement) {
             scrollInsideContainerWhenActiveDomElementIsOutOfView(
                 activeDomElement,

--- a/src/components/catalogue/Catalogue.wc.svelte
+++ b/src/components/catalogue/Catalogue.wc.svelte
@@ -5,8 +5,6 @@
 />
 
 <script lang="ts">
-    import { run } from "svelte/legacy";
-
     import { catalogueTextStore } from "../../stores/texts";
     import { catalogue } from "../../stores/catalogue";
     import type { ToggleAttribute } from "../../types/helpers";
@@ -51,19 +49,21 @@
             labelTo: texts.numberInput?.labelTo || "to",
         },
     };
+
     /**
      * Initialize the catalogue store with the given tree data
      * watch for changes from other components
      */
-    run(() => {
+    $effect(() => {
         if (treeData.length !== 0) {
             $catalogue = treeData;
         }
     });
+
     /**
      * Initialize the text store with the given texts
      */
-    run(() => {
+    $effect(() => {
         $catalogueTextStore = initializedTexts;
     });
 </script>

--- a/src/components/catalogue/StringInputComponent.svelte
+++ b/src/components/catalogue/StringInputComponent.svelte
@@ -7,7 +7,6 @@
     import { v4 as uuidv4 } from "uuid";
     import { addItemToQuery } from "../../stores/query";
     import type { QueryItem } from "../../types/queryData";
-    import { run } from "svelte/legacy";
     import type { StringCategory } from "../../types/catalogue";
     import QueryAddButtonComponent from "./QueryAddButtonComponent.svelte";
 
@@ -31,7 +30,6 @@
      */
     let inputValue: string = $state("");
 
-    let activeDomElement: HTMLElement | null = null; // Initialize as null or undefined
     /**
      * transforms the inputvalue to a QueryItem, adds it to the query store
      * and resets the input value and the focused item index
@@ -69,36 +67,6 @@
             addInputValueToStore();
         }
     };
-
-    /**
-     * scrolls the active dom element into view when it is out of view
-     * @param activeDomElement - the active dom element
-     */
-    const scrollInsideContainerWhenActiveDomElementIsOutOfView = (
-        activeDomElement: HTMLElement,
-    ): void => {
-        if (!activeDomElement) return;
-        const container: HTMLElement = activeDomElement.parentElement!;
-        const containerTop: number = container.scrollTop;
-        const containerBottom: number = containerTop + container.clientHeight;
-        const elementTop: number = activeDomElement.offsetTop;
-        const elementBottom: number =
-            elementTop + activeDomElement.clientHeight;
-
-        if (elementTop < containerTop) {
-            container.scrollTop = elementTop;
-        } else if (elementBottom > containerBottom) {
-            container.scrollTop = elementBottom - container.clientHeight;
-        }
-    };
-
-    run(() => {
-        if (activeDomElement) {
-            scrollInsideContainerWhenActiveDomElementIsOutOfView(
-                activeDomElement,
-            );
-        }
-    });
 </script>
 
 <div part="string-container">

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -5,8 +5,6 @@
 />
 
 <script lang="ts">
-    import { run } from "svelte/legacy";
-
     import Chart, { type ChartTypeRegistry } from "chart.js/auto";
     import { onMount } from "svelte";
     import {
@@ -589,7 +587,8 @@
 
         addItemToQuery(queryItem, $activeQueryGroupIndex);
     };
-    run(() => {
+
+    $effect(() => {
         setChartData($responseStore);
     });
 </script>

--- a/src/components/search-bar/SearchBarComponent.wc.svelte
+++ b/src/components/search-bar/SearchBarComponent.wc.svelte
@@ -5,9 +5,6 @@
 />
 
 <script lang="ts">
-    import { run } from "svelte/legacy";
-
-    import { writable } from "svelte/store";
     import type {
         AggregatedValue,
         Category,
@@ -156,11 +153,6 @@
     );
 
     /**
-     * stores the filtered list of autocomplete items
-     */
-    const inputOptions = writable<AutoCompleteItem[]>();
-
-    /**
      * input element binds to this variable. Used to focus the input element
      */
     let searchBarInput: HTMLInputElement;
@@ -170,10 +162,10 @@
     let inputValue: string = $state("");
 
     /**
-     * watches the input value and updates the input options
+     * stores the filtered list of autocomplete items
      */
-    run(() => {
-        $inputOptions = criteria.filter((item: AutoCompleteItem) => {
+    let inputOptions: AutoCompleteItem[] = $derived.by(() => {
+        return criteria.filter((item: AutoCompleteItem) => {
             /**
              * lets the user use a number followed by a colon to specify the search group. nice to have for the power users
              */
@@ -271,19 +263,19 @@
         if (event.key === "ArrowDown") {
             event.preventDefault();
             focusedItemIndex = focusedItemIndex + 1;
-            if (focusedItemIndex > $inputOptions.length - 1)
+            if (focusedItemIndex > inputOptions.length - 1)
                 focusedItemIndex = 0;
         }
         if (event.key === "ArrowUp") {
             event.preventDefault();
             focusedItemIndex = focusedItemIndex - 1;
             if (focusedItemIndex < 0)
-                focusedItemIndex = $inputOptions.length - 1;
+                focusedItemIndex = inputOptions.length - 1;
         }
         if (event.key === "Enter") {
             event.preventDefault();
             addInputValueToStore(
-                $inputOptions[focusedItemIndex],
+                inputOptions[focusedItemIndex],
                 extractTargetGroupFromInputValue(),
             );
         }
@@ -312,7 +304,7 @@
         }
     };
 
-    run(() => {
+    $effect(() => {
         if (activeDomElement) {
             scrollInsideContainerWhenActiveDomElementIsOutOfView(
                 activeDomElement,
@@ -420,10 +412,10 @@
     />
     {#if autoCompleteOpen && inputValue.length > 2}
         <ul part="lens-searchbar-autocomplete-options">
-            {#if $inputOptions?.length > 0}
+            {#if inputOptions?.length > 0}
                 <!-- eslint-disable-next-line svelte/require-each-key -->
-                {#each $inputOptions as inputOption, i}
-                    {#if $inputOptions
+                {#each inputOptions as inputOption, i}
+                    {#if inputOptions
                         .map((option) => option.name)
                         .indexOf(inputOption.name) === i}
                         <div part="autocomplete-options-item-name">
@@ -498,7 +490,6 @@
         on:clear-search={() => {
             inputValue = "";
             focusedItemIndex = -1;
-            $inputOptions = [];
         }}
     />
 </div>


### PR DESCRIPTION
I've removed the `scrollInsideContainerWhenActiveDomElementIsOutOfView` code from the string input. This is intended for the autocomplete dropdowns in the search bar and the autocomplete component and doesn't make sense for the string type.

Closes #255 