### PR TITLE
chore: adjust linting.yml in new app guide

### DIFF
--- a/book/src/guide/new-app.md
+++ b/book/src/guide/new-app.md
@@ -290,9 +290,9 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
             - run: npm ci
-            - run: npx svelte-check
             - run: npx prettier --check .
             - run: npx eslint .
-            - run: npx vite build
+            - run: npm run check
+            - run: npm run build
             - run: bash scripts/validate-json-schema.bash
 ```


### PR DESCRIPTION
I changed the `linting.yml` CI file in bbmri locator and ccp explorer to this. It's more robust this way because the scripts in package.json do a necessary `svelte-kit sync` before running the actual command.