### PR TITLE
chore: make setCatalogue and setOptions only log a warning if JSON sc…

### DIFF
--- a/src/stores/catalogue.ts
+++ b/src/stores/catalogue.ts
@@ -322,19 +322,18 @@ export const getCriteriaFromKey = (
 };
 
 /**
- * Set the catalogue. An exception is thrown if the catalogue does not match the JSON schema.
+ * Set the catalogue. A warning is logged to the browser console if the catalogue does not match the JSON schema.
  */
 export function setCatalogue(cat: Catalogue) {
+    catalogue.set(cat);
     const ajv = new Ajv({
         allErrors: true,
     });
     addFormats(ajv);
     const valid = ajv.validate(catalogueSchema, cat);
-    if (valid) {
-        catalogue.set(cat);
-    } else {
-        throw new Error(
-            "Catalogue not conform with JSON schema: " +
+    if (!valid) {
+        console.warn(
+            "Catalogue does not conform with JSON schema: " +
                 JSON.stringify(ajv.errors),
         );
     }

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -8,19 +8,18 @@ import optionsSchema from "../../schema/options.schema.json";
 export const lensOptions = writable<LensOptions | undefined>();
 
 /**
- * Set the options. An exception is thrown if the options do not match the JSON schema.
+ * Set the options. A warning is logged to the browser console if the options do not match the JSON schema.
  */
 export function setOptions(options: LensOptions) {
+    lensOptions.set(options);
     const ajv = new Ajv({
         allErrors: true,
     });
     addFormats(ajv);
     const valid = ajv.validate(optionsSchema, options);
-    if (valid) {
-        lensOptions.set(options);
-    } else {
-        throw new Error(
-            "Options not conform with JSON schema: " +
+    if (!valid) {
+        console.warn(
+            "Options do not conform with JSON schema: " +
                 JSON.stringify(ajv.errors),
         );
     }


### PR DESCRIPTION
When testing new lens features with current version of CCP explorer/BBMRI locator small schema mismatches are common and annoying if they block the functionality completely. I've changed `setCatalogue` and `setOptions` to update the stores also if the schema doesn't match and only show a warning in this case. CCP and BBMRI have CI that checks schema validity so these measures should hopefully be enough so people don't break it.