### PR TITLE
fix: solve some layout issues

### DIFF
--- a/dev.svelte
+++ b/dev.svelte
@@ -133,6 +133,11 @@
                     name: "B-",
                     description: "",
                 },
+                {
+                    key: "somethinglong",
+                    name: "This is a very long name for a blood group just to test the layout",
+                    description: "",
+                },
             ],
         },
         {
@@ -587,28 +592,30 @@
         <lens-negotiate-button title="Request Data"></lens-negotiate-button>
         <lens-search-modified-display></lens-search-modified-display>
         <lens-result-table></lens-result-table>
-        <lens-chart
-            title="Geschlecht"
-            catalogueGroupCode="gender"
-            chartType="pie"
-            displayLegends="true"
-        ></lens-chart>
-        <lens-chart
-            title="diagnosis"
-            catalogueGroupCode="diagnosis"
-            chartType="bar"
-            xAxisTitle="ICD-10-Codes"
-            yAxisTitle="Anzahl der Diagnosen"
-        ></lens-chart>
-        <lens-chart
-            title="diagnosis"
-            catalogueGroupCode="diagnosis"
-            indexAxis="y"
-            scaleType="logarithmic"
-            chartType="bar"
-            xAxisTitle="Anzahl der Diagnosen"
-            yAxisTitle="ICD-10-Codes"
-        ></lens-chart>
+        <div>
+            <lens-chart
+                title="Geschlecht"
+                catalogueGroupCode="gender"
+                chartType="pie"
+                displayLegends="true"
+            ></lens-chart>
+            <lens-chart
+                title="diagnosis"
+                catalogueGroupCode="diagnosis"
+                chartType="bar"
+                xAxisTitle="ICD-10-Codes"
+                yAxisTitle="Anzahl der Diagnosen"
+            ></lens-chart>
+            <lens-chart
+                title="diagnosis"
+                catalogueGroupCode="diagnosis"
+                indexAxis="y"
+                scaleType="logarithmic"
+                chartType="bar"
+                xAxisTitle="Anzahl der Diagnosen"
+                yAxisTitle="ICD-10-Codes"
+            ></lens-chart>
+        </div>
     </div>
 </div>
 

--- a/src/components/buttons/InfoButtonComponent.wc.svelte
+++ b/src/components/buttons/InfoButtonComponent.wc.svelte
@@ -103,7 +103,6 @@
     [part~="info-button"] {
         position: relative;
         cursor: pointer;
-        height: 100%;
         width: 38px;
         background-color: var(--white);
         border: solid 1px var(--blue);

--- a/src/components/catalogue/SingleSelectComponent.svelte
+++ b/src/components/catalogue/SingleSelectComponent.svelte
@@ -19,7 +19,7 @@
 <style>
     [part~="single-select-wrapper"] {
         display: grid;
-        grid-template-columns: max-content max-content max-content;
+        grid-template-columns: 1fr max-content max-content;
         column-gap: 10px;
         row-gap: 4px;
         align-items: center;

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -666,19 +666,23 @@
         </div>
     {/if}
 
-    <canvas
-        part="chart-canvas"
-        bind:this={canvas}
-        id="chart"
-        onclick={handleClickOnStratifier}
-    ></canvas>
+    <!-- For responsive charts, Charts.js requires a dedicated container for each canvas: https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note -->
+    <!-- The container requires `min-width: 0` or it won't shrink: https://github.com/chartjs/Chart.js/issues/4156#issuecomment-295180128 -->
+    <div style="min-width: 0;">
+        <canvas
+            part="chart-canvas"
+            bind:this={canvas}
+            id="chart"
+            onclick={handleClickOnStratifier}
+        ></canvas>
+    </div>
     <slot />
 </div>
 
 <style>
     [part~="chart-wrapper"] {
+        height: 100%;
         display: grid;
-        grid-template-rows: auto 1fr auto;
         position: relative;
         background-color: var(--white);
     }

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -668,7 +668,7 @@
 
     <!-- For responsive charts, Charts.js requires a dedicated container for each canvas: https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note -->
     <!-- The container requires `min-width: 0` or it won't shrink: https://github.com/chartjs/Chart.js/issues/4156#issuecomment-295180128 -->
-    <div style="min-width: 0;">
+    <div part="container-min-width-0">
         <canvas
             part="chart-canvas"
             bind:this={canvas}
@@ -680,6 +680,10 @@
 </div>
 
 <style>
+    [part~="container-min-width-0"] {
+        min-width: 0;
+    }
+
     [part~="chart-wrapper"] {
         height: 100%;
         display: grid;


### PR DESCRIPTION
I think we broke the chart layout in 0.5.1, from that version onwards charts only grow but never shrink.

There is this comment in a Chart.JS issue https://github.com/chartjs/Chart.js/issues/4156#issuecomment-295180128 that says you have to set `min-width: 0` on the Chart container so it can shrink. This is also what I am doing in the organoid dashboard. I'm a bit confused because I don't think we did this in 0.5.0 and graphs used to shrink anyways.

This PR sets `min-width: 0` on a dedicated chart container `div` so charts can shrink again. I've also fixed catalogue items so they wrap when they are too long. I also had to set `height: 100%` on the chart wrapper so it takes the entire vertical space that is reserved by the application for the chart. Some deal here, I am not sure why this wasn't needed before and is needed now.