### PR TITLE
One sided range query representation

### DIFF
--- a/src/components/catalogue/DatePickerComponent.svelte
+++ b/src/components/catalogue/DatePickerComponent.svelte
@@ -57,8 +57,7 @@
                 values: [
                     {
                         name: buildName(),
-                        // Empty string indicates absence of min/max
-                        value: { min: from ?? "", max: to ?? "" },
+                        value: { min: from || undefined, max: to || undefined },
                         queryBindId: uuidv4(),
                     },
                 ],

--- a/src/components/catalogue/NumberInputComponent.svelte
+++ b/src/components/catalogue/NumberInputComponent.svelte
@@ -57,8 +57,7 @@
                 values: [
                     {
                         name: buildName(),
-                        // TODO: 0 indicates absence of min/max, this should be changed so we can use 0 as a value
-                        value: { min: from ?? 0, max: to ?? 0 },
+                        value: { min: from ?? undefined, max: to ?? undefined },
                         queryBindId: uuidv4(),
                     },
                 ],

--- a/src/cql-translator-service/ast-to-cql-translator.ts
+++ b/src/cql-translator-service/ast-to-cql-translator.ts
@@ -433,19 +433,19 @@ const substituteRangeCQLExpression = (
     criterionSuffix: string,
     rangeCQL: string,
 ): string => {
-    const input = criterion.value as { min: number; max: number };
+    const input = criterion.value as { min?: number; max?: number };
     if (input === null) {
         console.warn(
             `Throwing away a ${criterionPrefix}Range${criterionSuffix} criterion, as it is not of type {min: number, max: number}!`,
         );
         return "";
     }
-    if (input.min === 0 && input.max === 0) {
+    if (input.min === undefined && input.max === undefined) {
         console.warn(
             `Throwing away a ${criterionPrefix}Range${criterionSuffix} criterion, as both dates are undefined!`,
         );
         return "";
-    } else if (input.min === 0) {
+    } else if (input.min === undefined) {
         const lowerThanDateTemplate = cqltemplate.get(
             `${criterionPrefix}LowerThan${criterionSuffix}`,
         );
@@ -458,7 +458,7 @@ const substituteRangeCQLExpression = (
                 input.min,
                 input.max,
             );
-    } else if (input.max === 0) {
+    } else if (input.max === undefined) {
         const greaterThanDateTemplate = cqltemplate.get(
             `${criterionPrefix}GreaterThan${criterionSuffix}`,
         );
@@ -515,10 +515,10 @@ const substituteCQLExpression = (
             codesystems.push(systemExpression);
         }
     }
-    if (min || min === 0) {
+    if (min !== undefined) {
         cqlString = cqlString.replace(new RegExp("{{D1}}"), min.toString());
     }
-    if (max || max === 0) {
+    if (max !== undefined) {
         cqlString = cqlString.replace(new RegExp("{{D2}}"), max.toString());
     }
     return cqlString;

--- a/src/stores/datarequests.ts
+++ b/src/stores/datarequests.ts
@@ -43,15 +43,14 @@ export const buildHumanReadableRecursively = (
                     !Array.isArray(child.value) &&
                     ("min" in child.value || "max" in child.value)
                 ) {
-                    const hasMin =
-                        "min" in child.value && child.value.min !== "";
-                    const hasMax =
-                        "max" in child.value && child.value.max !== "";
-                    if (hasMin && hasMax) {
+                    if (
+                        child.value.min !== undefined &&
+                        child.value.max !== undefined
+                    ) {
                         humanReadableQuery += `(${child.key} from ${child.value.min} to ${child.value.max})`;
-                    } else if (hasMin) {
+                    } else if (child.value.min !== undefined) {
                         humanReadableQuery += `(${child.key} greater than or equal to ${child.value.min})`;
-                    } else if (hasMax) {
+                    } else if (child.value.max !== undefined) {
                         humanReadableQuery += `(${child.key} less than or equal to ${child.value.max})`;
                     }
                 }

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -18,6 +18,6 @@ export type AstBottomLayerValue = {
         | string
         | boolean
         | Array<string>
-        | { min: number; max: number }
-        | { min: string; max: string }; // for dates
+        | { min?: number; max?: number } // For numeric ranges
+        | { min?: string; max?: string }; // For date ranges
 };

--- a/src/types/queryData.ts
+++ b/src/types/queryData.ts
@@ -14,8 +14,8 @@ export type QueryValue = {
     name: string;
     value:
         | string
-        | { min: number; max: number } // TODO: if user only specifies minimum or maximum, encode this as `number | undefined`, similar for dates
-        | { min: string; max: string }
+        | { min?: number; max?: number } // For numeric ranges
+        | { min?: string; max?: string } // For date ranges
         | AggregatedValue[][];
     queryBindId: string;
     description?: string;


### PR DESCRIPTION
In BBMRI sample locator one-sided ranges will cause the query to fail because focus does not support them. I guess this is better behavior than silently putting 0 in place of the missing value.