### PR TITLE
chore: focus autocomplete input when it is openend

### DIFF
--- a/src/components/catalogue/AutoCompleteComponent.svelte
+++ b/src/components/catalogue/AutoCompleteComponent.svelte
@@ -43,6 +43,8 @@
     };
 
     onMount(() => {
+        searchBarInput.focus();
+
         let subgroups: Criteria[] = [];
         criteria.forEach((element) => {
             if (element.subgroup != undefined) {


### PR DESCRIPTION
Focus autocomplete input when catalogue is expanded so the user can start typing immediately. Other input types already do this.

Closes #470 

