### PR TITLE
fix: close event source when server closes connection

### DIFF
--- a/src/backends/spot.ts
+++ b/src/backends/spot.ts
@@ -53,6 +53,11 @@ export async function createBeamTask(
         },
     );
 
+    eventSource.addEventListener("error", () => {
+        // Server closed the connection, which is expected when all sites have responded
+        eventSource.close();
+    });
+
     signal.addEventListener("abort", () => {
         eventSource.close();
     });


### PR DESCRIPTION
Removed this when rewriting the spot class to a function. Turns out this is needed or the same results will keep coming in and refreshing the graphs again and agin.