### PR TITLE
chore: remove catalogueKeyToResponseKeyMap option and unify the interface

### DIFF
--- a/book/src/releases/v0.6.0.md
+++ b/book/src/releases/v0.6.0.md
@@ -157,4 +157,20 @@ Facet counts now use the `spotUrl` from the Lens options with `/prism` automatic
 
 ### Removal of `catalogueKeyToResponseKeyMap` option
 
-In previous versions, `catalogueKeyToResponseKeyMap` was used to map catalogue keys to response keys with different names, and this logic was handled entirely within Lens. With the transition to the new result format and local result processing in the application, this mapping is no longer needed by Lens. Charts now use a simple dataKey string to directly reference strata in the result data.
+In previous versions, `catalogueKeyToResponseKeyMap` was used in the `<lens-chart>` component to map catalogue keys to response keys with different names. The map has been removed and the `<lens-chart>` component now takes the response key. In your Lens options remove the map:
+
+```diff
+-"catalogueKeyToResponseKeyMap": [
+-    [
+-        "age_at_diagnosis",
+-        "donor_age"
+-    ],
+-]
+```
+
+And update your usage of `<lens-chart>` accordingly:
+
+```diff
+-<lens-chart catalogueGroupCode="age_at_diagnosis">
++<lens-chart dataKey="donor_age">
+```

--- a/book/src/releases/v0.6.0.md
+++ b/book/src/releases/v0.6.0.md
@@ -154,3 +154,7 @@ Facet counts now use the `spotUrl` from the Lens options with `/prism` automatic
      }
  },
 ```
+
+### Removal of `catalogueKeyToResponseKeyMap` option
+
+In previous versions, `catalogueKeyToResponseKeyMap` was used to map catalogue keys to response keys with different names, and this logic was handled entirely within Lens. With the transition to the new result format and local result processing in the application, this mapping is no longer needed by Lens. Charts now use a simple dataKey string to directly reference strata in the result data.

--- a/dev.svelte
+++ b/dev.svelte
@@ -396,20 +396,20 @@
         <div>
             <lens-chart
                 title="Geschlecht"
-                catalogueGroupCode="gender"
+                dataKey="gender"
                 chartType="pie"
                 displayLegends="true"
             ></lens-chart>
             <lens-chart
                 title="diagnosis"
-                catalogueGroupCode="diagnosis"
+                dataKey="diagnosis"
                 chartType="bar"
                 xAxisTitle="ICD-10-Codes"
                 yAxisTitle="Anzahl der Diagnosen"
             ></lens-chart>
             <lens-chart
                 title="diagnosis"
-                catalogueGroupCode="diagnosis"
+                dataKey="diagnosis"
                 indexAxis="y"
                 scaleType="logarithmic"
                 chartType="bar"

--- a/schema/options.schema.json
+++ b/schema/options.schema.json
@@ -122,17 +122,6 @@
           "description": "Whether to automatically update the query in the URL when it changes (default: true)",
           "type": "boolean"
         },
-        "catalogueKeyToResponseKeyMap": {
-          "items": {
-            "items": {
-              "type": "string"
-            },
-            "maxItems": 2,
-            "minItems": 2,
-            "type": "array"
-          },
-          "type": "array"
-        },
         "chartOptions": {
           "$ref": "#/definitions/ChartOptions"
         },

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -27,7 +27,6 @@
 
     interface Props {
         title?: string; // e.g. 'Gender Distribution'
-        catalogueGroupCode?: string; // e.g. "gender"
         indexAxis?: string;
         xAxisTitle?: string;
         yAxisTitle?: string;
@@ -36,6 +35,7 @@
         displayLegends?: boolean;
         chartType?: keyof ChartTypeRegistry;
         scaleType?: string;
+        dataKey: string;
         perSite?: boolean;
         groupRange?: number;
         groupingDivider?: string;
@@ -48,13 +48,13 @@
 
     let {
         title = "",
-        catalogueGroupCode = "",
         indexAxis = "x",
         xAxisTitle = "",
         yAxisTitle = "",
         clickToAddState = false,
         headers = new Map<string, string>(),
         displayLegends = false,
+        dataKey = "",
         chartType = "pie",
         scaleType = "linear",
         perSite = false,
@@ -88,15 +88,8 @@
         backgroundHoverColor = ["#aaaaaa"],
     }: Props = $props();
 
-    // This is undefined if the lens options are not loaded yet
     let options: ChartOption | undefined = $derived(
-        $lensOptions?.chartOptions?.[catalogueGroupCode],
-    );
-
-    let responseGroupCode: string = $derived(
-        new Map($lensOptions?.catalogueKeyToResponseKeyMap).get(
-            catalogueGroupCode,
-        ) || catalogueGroupCode,
+        $lensOptions?.chartOptions?.[dataKey],
     );
 
     /**
@@ -197,12 +190,12 @@
 
     const accumulateValues = (
         valuesToAccumulate: string[],
-        catalogueGroupCode: string,
+        datakey: string,
     ): number => {
         let aggregatedData = 0;
 
         valuesToAccumulate.forEach((value: string) => {
-            aggregatedData += getStratum(catalogueGroupCode, value);
+            aggregatedData += getStratum(datakey, value);
         });
         return aggregatedData;
     };
@@ -222,7 +215,7 @@
 
         if (perSite) {
             dataSet = chartLabels.map((label: string) =>
-                getSiteTotal(label, catalogueGroupCode),
+                getSiteTotal(label, dataKey),
             );
 
             let remove_indexes: number[] = [];
@@ -279,7 +272,7 @@
             options.accumulatedValues.forEach((valueToAccumulate) => {
                 const aggregationCount: number = accumulateValues(
                     valueToAccumulate.values,
-                    catalogueGroupCode,
+                    dataKey,
                 );
                 if (aggregationCount > 0) {
                     combinedSubGroupData.data.push(aggregationCount);
@@ -335,7 +328,7 @@
     ): { labels: string[]; data: number[] } => {
         const labelsToData = new SvelteMap<string, number>();
         for (const label of labels) {
-            const value = getStratum(responseGroupCode, label);
+            const value = getStratum(dataKey, label);
 
             if (!label.includes(divider) || divider === "") {
                 /*
@@ -392,7 +385,7 @@
         if (perSite) {
             chartLabels.push(...siteStatus.keys());
         } else {
-            chartLabels = getStrata(responseGroupCode);
+            chartLabels = getStrata(dataKey);
         }
         chartLabels = filterRegexMatch(chartLabels);
         chartLabels.sort(customSort);
@@ -550,7 +543,7 @@
                 parentCategory.childCategories?.forEach(
                     (childCategorie: Category) => {
                         if (
-                            childCategorie.key === catalogueGroupCode &&
+                            childCategorie.key === dataKey &&
                             (childCategorie.fieldType === "single-select" ||
                                 childCategorie.fieldType === "autocomplete" ||
                                 childCategorie.fieldType === "number")

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -188,14 +188,11 @@
         },
     };
 
-    const accumulateValues = (
-        valuesToAccumulate: string[],
-        datakey: string,
-    ): number => {
+    const accumulateValues = (valuesToAccumulate: string[]): number => {
         let aggregatedData = 0;
 
         valuesToAccumulate.forEach((value: string) => {
-            aggregatedData += getStratum(datakey, value);
+            aggregatedData += getStratum(dataKey, value);
         });
         return aggregatedData;
     };
@@ -272,7 +269,6 @@
             options.accumulatedValues.forEach((valueToAccumulate) => {
                 const aggregationCount: number = accumulateValues(
                     valueToAccumulate.values,
-                    dataKey,
                 );
                 if (aggregationCount > 0) {
                     combinedSubGroupData.data.push(aggregationCount);

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -8,7 +8,6 @@ export type LensOptions = {
     /** List of sites to query used by `querySpot` function and facet counts. If not set no sites are sent to Spot and Spot determines the sites to query. */
     sitesToQuery?: string[];
     chartOptions?: ChartOptions;
-    catalogueKeyToResponseKeyMap?: [string, string][];
     siteMappings?: { [key: string]: string };
     negotiateOptions?: NegotiateOptions;
     tableOptions?: TableOptions;


### PR DESCRIPTION
### Description

This PR does remove the catalogueKeyToResponseMap from the options. Lens Chart was the only component relying on it. 
BREAKING CHANGE: a lens chart now needs a dataKey

Closes #521 
