### PR TITLE
chore: use siteMappings for per-site charts

### DIFF
--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -440,16 +440,18 @@
             });
         }
 
-        /**
-         * set the labels of the chart
-         * if a legend mapping is set, use the legend mapping
-         */
-        chart.data.labels =
-            options?.legendMapping !== undefined
-                ? chartLabels.map(
-                      (label) => options.legendMapping?.[label] || "",
-                  )
-                : chartLabels;
+        // Set the chart labels, using either the legend mapping or the site mappings
+        if (options?.legendMapping !== undefined) {
+            chart.data.labels = chartLabels.map(
+                (label) => options.legendMapping?.[label] ?? label,
+            );
+        } else if (perSite && $lensOptions?.siteMappings !== undefined) {
+            chart.data.labels = chartLabels.map(
+                (label) => $lensOptions.siteMappings?.[label] ?? label,
+            );
+        } else {
+            chart.data.labels = chartLabels;
+        }
 
         let max = Math.max(
             ...chartData.data.map((dataset) => Math.max(...dataset.data)),


### PR DESCRIPTION
The CCP explorer options.json had to list site mappings twice:

https://github.com/samply/ccp-explorer/blob/aa0ca7a7fe89b938b22f0829916a27a13fb66427/static/options-ccp-prod.json#L9-L55

This PR makes per-site charts look into `siteMappings` so you don't have to repeat this mapping in the options.