### PR TITLE
chore: fix ESLint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import svelte from "eslint-plugin-svelte";
 import svelteConfig from "./svelte.config.js";
 
 export default defineConfig([
-    globalIgnores(["dist", "book/book"]),
+    globalIgnores(["dist", "book/book", "docs/assets"]),
     // Recommended JavaScript and TypeScript lints
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -23,6 +23,7 @@
     import { lensOptions } from "../../stores/options";
     import type { ChartOption } from "../../types/options";
     import type { ChartDataSets } from "../../types/charts";
+    import { SvelteMap } from "svelte/reactivity";
 
     interface Props {
         title?: string; // e.g. 'Gender Distribution'
@@ -332,7 +333,7 @@
         divider: string,
         labels: string[],
     ): { labels: string[]; data: number[] } => {
-        const labelsToData = new Map<string, number>();
+        const labelsToData = new SvelteMap<string, number>();
         for (const label of labels) {
             const value = getStratum(responseGroupCode, label);
 

--- a/src/components/search-bar/SearchBarComponent.wc.svelte
+++ b/src/components/search-bar/SearchBarComponent.wc.svelte
@@ -26,6 +26,7 @@
     import { showErrorToast } from "../../stores/toasts";
     import { translate } from "../../helpers/translations";
     import { get } from "svelte/store";
+    import { SvelteURLSearchParams } from "svelte/reactivity";
 
     interface Props {
         /** The string to display when no matches are found */
@@ -384,7 +385,9 @@
                         ...new TextEncoder().encode(JSON.stringify(query)),
                     ),
                 );
-                const params = new URLSearchParams(window.location.search);
+                const params = new SvelteURLSearchParams(
+                    window.location.search,
+                );
                 params.set("query", encodedQuery);
                 const newUrl =
                     window.location.pathname +


### PR DESCRIPTION
New ESLint version added a new lint that needs to be fixed. Also disabled ESLint for the javascript generated by typedoc.