### PR TITLE
chore: move Spot URL and sites to query to Lens options

### DIFF
--- a/book/src/guide/facet-counts.md
+++ b/book/src/guide/facet-counts.md
@@ -1,14 +1,13 @@
 # Facet counts
 
-Lens can query facet counts from a backend and display them in the catalogue. Facet counts are roughly speaking the number of results one would get when only searching for that criteria.
+Lens can query facet counts from [Spot](https://github.com/samply/spot) and display them in the catalogue. Facet counts are the number of results one would get when only searching for that criteria.
 
 ![Example of facet counts](facet-counts.png)
 
-To enable facet counts add the following options:
+To enable facet counts add the following to the Lens options:
 
 ```json
 "facetCount": {
-    "backendUrl": "http://localhost:5124/prism",
     "hoverText": {
         "gender": "Matching patients for this criterion only",
         "diagnosis": "Total number of this diagnosis across all patients",
@@ -17,9 +16,13 @@ To enable facet counts add the following options:
 },
 ```
 
-`hoverText` controls the text that is displayed when hovering the mouse over the number chips.
+`hoverText` controls the text that is displayed when hovering the mouse over the number chips. You also have to set the Spot URL in the Lens options:
 
-Lens POSTs an array of sites (e.g. `{"sites": ["berlin", "munich"]}`) to the endpoint and expects facet counts in the following format:
+```json
+"spotUrl": "https://locator-dev.bbmri-eric.eu/backend"
+```
+
+Lens POSTs an array of sites (e.g. `{"sites": ["berlin", "munich"]}`) to the appropriate Spot endpoint and expects facet counts in the following format:
 
 ```json
 {

--- a/book/src/guide/query.md
+++ b/book/src/guide/query.md
@@ -155,6 +155,18 @@ window.addEventListener("lens-search-triggered", () => {
 });
 ```
 
+The [`querySpot`](https://samply.github.io/lens/docs/functions/querySpot.html) function requires that you set the Spot URL to the Lens options:
+
+```json
+"spotUrl": "https://locator-dev.bbmri-eric.eu/backend"
+```
+
+Usually Spot determines the list of sites to query via its `SITES` environment variable. You can optionally override the list of sites in the Lens options:
+
+```json
+"sitesToQuery": ["lodz-test", "uppsala-test", "eric-test", "DNB-Test"]
+```
+
 Learn how to pass results to Lens in the [Showing results](./results.md) guide.
 
 ### Querying Focus with CQL

--- a/book/src/guide/query.md
+++ b/book/src/guide/query.md
@@ -155,7 +155,7 @@ window.addEventListener("lens-search-triggered", () => {
 });
 ```
 
-The [`querySpot`](https://samply.github.io/lens/docs/functions/querySpot.html) function requires that you set the Spot URL to the Lens options:
+The [`querySpot`](https://samply.github.io/lens/docs/functions/querySpot.html) function requires that you set the Spot URL in the Lens options:
 
 ```json
 "spotUrl": "https://locator-dev.bbmri-eric.eu/backend"

--- a/book/src/releases/v0.6.0.md
+++ b/book/src/releases/v0.6.0.md
@@ -139,3 +139,18 @@ We've renamed some types to indicate that they are specific to the FHIR standard
 | `SiteData`    | `FhirMeasureReport` |
 | `Measure`     | `FhirMeasure`       |
 | `MeasureItem` | `FhirMeasureItem`   |
+
+### Facet counts use `spotUrl`
+
+Facet counts now use the `spotUrl` from the Lens options with `/prism` automatically appended:
+
+```diff
++"spotUrl": "https://locator-dev.bbmri-eric.eu/backend",
+ "facetCount": {
+-    "backendUrl": "https://locator-dev.bbmri-eric.eu/backend/prism",
+     "hoverText": {
+         "gender": "Matching patients for this criterion only",
+         ...
+     }
+ },
+```

--- a/schema/options.schema.json
+++ b/schema/options.schema.json
@@ -63,10 +63,6 @@
     "FacetCountOptions": {
       "additionalProperties": false,
       "properties": {
-        "backendUrl": {
-          "description": "URL of the backend that provides facet counts",
-          "type": "string"
-        },
         "hoverText": {
           "additionalProperties": {
             "type": "string"
@@ -76,7 +72,6 @@
         }
       },
       "required": [
-        "backendUrl",
         "hoverText"
       ],
       "type": "object"
@@ -160,6 +155,17 @@
             "type": "string"
           },
           "type": "object"
+        },
+        "sitesToQuery": {
+          "description": "List of sites to query used by `querySpot` function and facet counts. If not set no sites are sent to Spot and Spot determines the sites to query.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "spotUrl": {
+          "description": "URL of the Spot API endpoint used by `querySpot` function and facet counts.",
+          "type": "string"
         },
         "tableOptions": {
           "$ref": "#/definitions/TableOptions"

--- a/src/components/catalogue/Catalogue.wc.svelte
+++ b/src/components/catalogue/Catalogue.wc.svelte
@@ -53,9 +53,15 @@
         lensOptions.subscribe((opts) => {
             if (opts !== undefined && !didRun) {
                 if (opts.facetCount) {
-                    fetchFacetCounts(opts.facetCount.backendUrl);
-                    didRun = true;
+                    if (!opts.spotUrl) {
+                        console.warn(
+                            "No Spot URL set in options, facet counts will not be fetched.",
+                        );
+                    } else {
+                        fetchFacetCounts(opts.spotUrl);
+                    }
                 }
+                didRun = true;
             }
         });
     });

--- a/src/stores/facetCounts.ts
+++ b/src/stores/facetCounts.ts
@@ -15,10 +15,9 @@ export const facetCounts = writable<Record<string, Record<string, number>>>({});
  * - Strips group from response, stores stratifier -> stratum -> number
  */
 export async function fetchFacetCounts(backendURL: string) {
-    const url = backendURL.replace(/\/$/, "") + "/criteria";
+    const url = backendURL.replace(/\/$/, "") + "/prism/criteria";
     const options = get(lensOptions);
-    // Try to get sites from siteMappings, fallback to empty array
-    const sites = Object.keys(options?.siteMappings || {});
+    const sites: string[] | undefined = options?.sitesToQuery;
     try {
         const response = await fetch(url, {
             method: "POST",

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -3,6 +3,10 @@
 // `npm run schemagen` to update the JSON schema.
 
 export type LensOptions = {
+    /** URL of the Spot API endpoint used by `querySpot` function and facet counts. */
+    spotUrl?: string;
+    /** List of sites to query used by `querySpot` function and facet counts. If not set no sites are sent to Spot and Spot determines the sites to query. */
+    sitesToQuery?: string[];
     chartOptions?: ChartOptions;
     catalogueKeyToResponseKeyMap?: [string, string][];
     siteMappings?: { [key: string]: string };
@@ -20,8 +24,6 @@ export type LensOptions = {
 };
 
 export type FacetCountOptions = {
-    /** URL of the backend that provides facet counts */
-    backendUrl: string;
     /** Hover text for each stratifier in the catalogue */
     hoverText: Record<string, string>;
 };


### PR DESCRIPTION
Previous function signature was `querySpot(backendUrl: string, sites: string[], query: string, signal: AbortSignal)`. This PR changes it to `querySpot(query: string, signal: AbortSignal)` and moves the spot URL and sites list to the Lens options, e.g.:

```json
"spotUrl": "https://locator-dev.bbmri-eric.eu/backend",
"sitesToQuery": ["lodz-test", "uppsala-test", "eric-test", "DNB-Test"]
```

`sitesToQuery` is optional, if not specified no sites will be sent to Spot and Spot will use its `SITES` environment variable to determine which sites to query. So applications can choose if they want to explicitly specify sites to query in the options.json or use the `SITES` environment variable on the deployment server to control the sites to query.

Facet counts have been adjusted to also use `spotUrl` and `sitesToQuery` (same fallback to the `SITES` environment variable of Spot):

Closes #533 