### PR TITLE
chore: fix question mark cursor always showing

### DIFF
--- a/src/components/catalogue/SingleSelectItemComponent.svelte
+++ b/src/components/catalogue/SingleSelectItemComponent.svelte
@@ -37,7 +37,7 @@
     }
 </script>
 
-{#if criterion.description != ""}
+{#if criterion.description}
     <abbr part="lens-singleselect-item-underline" title={criterion.description}
         >{criterion.name}</abbr
     >


### PR DESCRIPTION
Previously the question mark cursor was always showing when hovering over criteria in the catalogue even if not underlined. This fixes it so the question mark cursor only shows if a criteria is underlined and has a description.