### PR TITLE
chore: remove additional properties when validation options and catalogue

### DIFF
--- a/src/stores/catalogue.ts
+++ b/src/stores/catalogue.ts
@@ -328,6 +328,7 @@ export function setCatalogue(cat: Catalogue) {
     catalogue.set(cat);
     const ajv = new Ajv({
         allErrors: true,
+        removeAdditional: true,
     });
     addFormats(ajv);
     const valid = ajv.validate(catalogueSchema, cat);

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -14,6 +14,7 @@ export function setOptions(options: LensOptions) {
     lensOptions.set(options);
     const ajv = new Ajv({
         allErrors: true,
+        removeAdditional: true,
     });
     addFormats(ajv);
     const valid = ajv.validate(optionsSchema, options);


### PR DESCRIPTION
This is useful if an application extends the LensOptions type to add their own application-specific options