### PR TITLE
Improve docs

### DIFF
--- a/book/src/guide/catalogue.md
+++ b/book/src/guide/catalogue.md
@@ -2,8 +2,6 @@
 
 The catalogue contains all possible query elements used in your search or exploration application. Lens expects a catalogue to be provided during initialization — even an empty one is valid.
 
-The catalogue takes a JSON input, which either could be provided locally or via a REST call.
-
 The structure of the catalogue is defined in [schema](https://github.com/samply/lens/blob/develop/schema/catalogue.schema.json) and [type](https://samply.github.io/lens/docs/types/Catalogue.html). Validating your catalogue can be done within VS Code with the schema, see [here](./new-app.md#schema-validation).
 
 ## Subgroups

--- a/book/src/guide/new-app.md
+++ b/book/src/guide/new-app.md
@@ -81,7 +81,7 @@ Now run `npm run dev` and open <http://localhost:5173/> in your browser. You sho
 
 Your application must pass two objects to Lens. The [LensOptions](https://samply.github.io/lens/docs/types/LensOptions.html) object contains general configuration options and the [Catalogue](https://samply.github.io/lens/docs/types/Catalogue.html) object describes what users can search for. You can define these objects in TypeScript but many applications in the Samply organization define them in JSON files.
 
-Assuming you are using JSON files, create the file `src/options.json` containing the empty object `{}` and the file `src/catalogue.json` with the following content:
+Assuming you are using JSON files, create the file `src/config/options.json` containing the empty object `{}` and the file `src/config/catalogue.json` with the following content:
 
 ```json
 [
@@ -116,8 +116,8 @@ Add the following to the top of `src/App.svelte` to load the JSON files and pass
         type LensOptions,
         type Catalogue,
     } from "@samply/lens";
-    import options from "./options.json";
-    import catalogue from "./catalogue.json";
+    import options from "./config/options.json";
+    import catalogue from "./config/catalogue.json";
     onMount(() => {
         setOptions(options as LensOptions);
         setCatalogue(catalogue as Catalogue);
@@ -136,8 +136,8 @@ Lens includes JSON schema definitions for the options and the catalogue type. Cr
 
 ```bash
 set -e # Return non-zero exit status if one of the validations fails
-npx ajv validate -c ajv-formats -s node_modules/@samply/lens/schema/options.schema.json -d src/options.json
-npx ajv validate -c ajv-formats -s node_modules/@samply/lens/schema/catalogue.schema.json -d src/catalogue.json
+npx ajv validate -c ajv-formats -s node_modules/@samply/lens/schema/options.schema.json -d src/config/options.json
+npx ajv validate -c ajv-formats -s node_modules/@samply/lens/schema/catalogue.schema.json -d src/config/catalogue.json
 ```
 
 Then install the required dependencies and test the script:
@@ -171,18 +171,28 @@ You can also configure VS Code to validate your JSON files against the schema de
 It is a common requirement to load different options in test and production. You can achieve this by using [a feature of SvelteKit](https://svelte.dev/tutorial/kit/env-dynamic-public) that makes environment variables from the server available in the browser. Applications in the Samply organization commonly accept the following environment variables:
 
 - `PUBLIC_ENVIRONMENT`: Accepts the name of the environment, e.g. `production` or `test`
-- `PUBLIC_BACKEND_URL`: Overwrites the URL of the backend that your application queries
+- `PUBLIC_SPOT_URL`: Overwrites the URL of the [Spot](https://github.com/samply/spot) backend that your application queries
 
-For example you could handle the `PUBLIC_ENVIRONMENT` variable as follows:
+For example you could handle the these variable as follows:
 
 ```html
 <script lang="ts">
-       import { env } from "$env/dynamic/public";
-       ...
+    import type { LensOptions } from "@samply/lens";
+    import { env } from "$env/dynamic/public";
+    import optionsProd from "./config/options.json";
+    import optionsTest from "./config/options-test.json";
+    ...
     onMount(() => {
-           setOptions(env.PUBLIC_ENVIRONMENT === "test" ? testOptions : prodOptions);
+        let options: LensOptions = optionsProd;
+        if (env.PUBLIC_ENVIRONMENT === 'test') {
+            options = optionsTest;
+        }
+        if (env.PUBLIC_SPOT_URL) {
+            options.spotUrl = env.PUBLIC_SPOT_URL;
+        }
+        setOptions(options);
     });
-       ...
+    ...
 </script>
 ```
 

--- a/book/src/guide/query.md
+++ b/book/src/guide/query.md
@@ -171,7 +171,7 @@ Learn how to pass results to Lens in the [Showing results](./results.md) guide.
 
 ### Querying Focus with CQL
 
-Some applications send CQL queries to Focus. In this case you need AST to CQL translation code in your application. You can get started by copying and adjusting the [`ast-to-cql-translator.ts`](https://github.com/samply/ccp-explorer/blob/main/src/lib/ast-to-cql-translator.ts), [`cqlquery-mappings.ts`](https://github.com/samply/ccp-explorer/blob/main/src/lib/cqlquery-mappings.ts) and [`measures.ts`](https://github.com/samply/ccp-explorer/blob/main/src/measures.ts) files from the CCP explorer repository. Sending the query would then look as follows:
+Some applications send CQL queries to Focus. In this case you need AST to CQL translation code in your application. You can get started by copying and adjusting the [`ast-to-cql-translator.ts`](https://github.com/samply/ccp-explorer/blob/main/src/lib/ast-to-cql-translator.ts), [`cqlquery-mappings.ts`](https://github.com/samply/ccp-explorer/blob/main/src/lib/cqlquery-mappings.ts) and [`measures.ts`](https://github.com/samply/ccp-explorer/blob/main/src/lib/measures.ts) files from the CCP explorer repository. Sending the query would then look as follows:
 
 ```ts
 import {


### PR DESCRIPTION
Changes to docs:
* Fix link to measures.ts file in CCP explorer repo
* Recommend importing options.json and catalogue.json instead of loading them via fetch. Advantages: no more outdated cached options issues in production and hot reload of options and catalogue during development