### PR TITLE
Fixes to the documentation in the mdbook.

### DIFF
--- a/book/src/components/chart.md
+++ b/book/src/components/chart.md
@@ -1,6 +1,6 @@
 # Chart
 
-The `lens-chart` component provides a styled wrapper for visualizing data using Chart.js. It handles dynamic display behaviors like toggling chart visibility, showing hints, and rendering a fallback message when no data is available. Some Options are setable via [ChartOption](https://samply.github.io/lens/docs/types/ChartOption.html) and some are set via props.
+The `lens-chart` component provides a styled wrapper for visualizing data using Chart.js. It handles dynamic display behaviors like toggling chart visibility, showing hints, and rendering a fallback message when no data is available. Some Options are set via [ChartOption](https://samply.github.io/lens/docs/types/ChartOption.html) and some are set via props.
 
 ![Example of a lens chart](pics/chart1.png)
 

--- a/book/src/components/negotiatebutton.md
+++ b/book/src/components/negotiatebutton.md
@@ -1,6 +1,6 @@
 # Negotiate Button
 
-The `lens-negotiate-button` component allows users to initiate a data request. It becomes active when one or more (site/data sources) are selected. Depending on the configuration, it either dispatches a general event or starts a negotiation through the BBMRI-ERIC Negotiator service. The button is disabled by default when no data source is selected. Fires a global `lens-negotiate-triggered` event when clicked.
+The `lens-negotiate-button` component allows users to initiate a data request. It becomes active when one or more (site/data sources) are selected. Depending on the configuration, it either dispatches a general event or starts a negotiation through the BBMRI-ERIC Negotiator service. The button is disabled by default when no data source is selected. It fires a global `lens-negotiate-triggered` event when clicked.
 
 Optionally integrates with the [BBMRI-ERIC Negotiator](https://www.bbmri-eric.eu/) when `type` is set to `"Negotiator"`.
 

--- a/book/src/components/queryspinner.md
+++ b/book/src/components/queryspinner.md
@@ -9,7 +9,7 @@ The `<lens-query-spinner>` component provides a visual indication that a query i
 The spinner appears when a search is in progress and disappears once all site responses are received.
 
 ```html
-<lens-query-spinner size="24px" />
+<lens-query-spinner size="24px"></lens-query-spinner>
 ```
 
 ---

--- a/book/src/components/resultsummary.md
+++ b/book/src/components/resultsummary.md
@@ -6,7 +6,7 @@ The `lens-result-summary` component displays a compact summary of result metrics
 
 ## Example
 
-To use it, define the configuration in the Lens options and include the component in your HTML:
+To use the component, define the configuration in the Lens [resultSummaryOptions](https://samply.github.io/lens/docs/types/ResultSummaryOptions.html) (in the `src/config/options.json` file as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
 
 ```json
 "resultSummaryOptions": {
@@ -19,14 +19,30 @@ To use it, define the configuration in the Lens options and include the componen
         }
     ]
 }
+```
 
+The `resultSummaryOptions` could also be set in JavaScript like this:
+
+```JavaScript
+let resultSummaryOptions = {
+  title: "Results",
+  infoButtonText: "This is a tooltip",
+  dataTypes: [
+    {
+      title: "Patients",
+      dataKey: "patients",
+    },
+    ],
+};
+
+options.resultSummaryOptions = resultSummaryOptions;
 ```
 
 ---
 
 ## Usage
 
-The component doesn't use any props and is only set via the [options](https://samply.github.io/lens/docs/types/ResultSummaryOptions.html)
+The component (which doesn't use any props) can then be included in your HTML:
 
 ```svelte
 <lens-result-summary></lens-result-summary>

--- a/book/src/components/resultsummary.md
+++ b/book/src/components/resultsummary.md
@@ -6,7 +6,7 @@ The `lens-result-summary` component displays a compact summary of result metrics
 
 ## Example
 
-To use the component, define the configuration in the Lens [resultSummaryOptions](https://samply.github.io/lens/docs/types/ResultSummaryOptions.html) (in the `src/config/options.json` file as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
+To use the component, define the configuration in the Lens [resultSummaryOptions](https://samply.github.io/lens/docs/types/ResultSummaryOptions.html) (as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
 
 ```json
 "resultSummaryOptions": {
@@ -19,23 +19,6 @@ To use the component, define the configuration in the Lens [resultSummaryOptions
         }
     ]
 }
-```
-
-The `resultSummaryOptions` could also be set in JavaScript like this:
-
-```JavaScript
-let resultSummaryOptions = {
-  title: "Results",
-  infoButtonText: "This is a tooltip",
-  dataTypes: [
-    {
-      title: "Patients",
-      dataKey: "patients",
-    },
-    ],
-};
-
-options.resultSummaryOptions = resultSummaryOptions;
 ```
 
 ---

--- a/book/src/components/resulttable.md
+++ b/book/src/components/resulttable.md
@@ -33,7 +33,7 @@ Each row includes a checkbox to select that data source for a data request. The 
 
 ## Example
 
-To use the table, define the configuration in the Lens [tableOptions](https://samply.github.io/lens/docs/types/TableOptions.html) (in the `src/config/options.json` file as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
+To use the table, define the configuration in the Lens [tableOptions](https://samply.github.io/lens/docs/types/TableOptions.html) (as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
 
 ```json
 "tableOptions": {
@@ -48,25 +48,6 @@ To use the table, define the configuration in the Lens [tableOptions](https://sa
         }
     ]
 }
-```
-
-The `tableOptions` could also be set in JavaScript like this:
-
-```JavaScript
-let tableOptions = {
-  headerData: [
-    {
-      title: "Sites",
-      dataKey: "site",
-    },
-    {
-      title: "Patients",
-      dataKey: "patients",
-    },
-  ],
-};
-
-options.tableOptions = tableOptions;
 ```
 
 ---

--- a/book/src/components/resulttable.md
+++ b/book/src/components/resulttable.md
@@ -33,7 +33,7 @@ Each row includes a checkbox to select that data source for a data request. The 
 
 ## Example
 
-To use the table, define the `tableOptions` and include the component in your HTML:
+To use the table, define the configuration in the Lens [tableOptions](https://samply.github.io/lens/docs/types/TableOptions.html) (in the `src/config/options.json` file as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):
 
 ```json
 "tableOptions": {
@@ -50,8 +50,34 @@ To use the table, define the `tableOptions` and include the component in your HT
 }
 ```
 
+The `tableOptions` could also be set in JavaScript like this:
+
+```JavaScript
+let tableOptions = {
+  headerData: [
+    {
+      title: "Sites",
+      dataKey: "site",
+    },
+    {
+      title: "Patients",
+      dataKey: "patients",
+    },
+  ],
+};
+
+options.tableOptions = tableOptions;
+```
+
+---
+
+## Usage
+
+The component can then be included in your HTML:
+
 ```svelte
-<lens-result-table title="Result Table" pageSize={25} pageSizeSwitcher={true} />
+<lens-result-table title="Result Table" pageSize={25} pageSizeSwitcher={true}
+></lens-result-table>
 ```
 
 ---

--- a/book/src/guide/new-app.md
+++ b/book/src/guide/new-app.md
@@ -152,20 +152,18 @@ bash scripts/validate-json-schema.bash
 You can also configure VS Code to validate your JSON files against the schema definitions. This will show validation errors in your editor and provide IntelliSense. To do so add the following configuration to your projects `.vscode/settings.json`:
 
 ```json
-"json.schemas": [
-    {
-        "fileMatch": [
-            "catalogue*.json"
-        ],
-        "url": "./node_modules/@samply/lens/schema/catalogue.schema.json",
-    },
+{
+    "json.schemas": [
         {
-        "fileMatch": [
-            "options*.json"
-        ],
-        "url": "./node_modules/@samply/lens/schema/options.schema.json",
-    },
-]
+            "fileMatch": ["catalogue*.json"],
+            "url": "./node_modules/@samply/lens/schema/catalogue.schema.json"
+        },
+        {
+            "fileMatch": ["options*.json"],
+            "url": "./node_modules/@samply/lens/schema/options.schema.json"
+        }
+    ]
+}
 ```
 
 ### Test environment
@@ -175,7 +173,9 @@ It is a common requirement to load different options in test and production. You
 - `PUBLIC_ENVIRONMENT`: Accepts the name of the environment, e.g. `production` or `test`
 - `PUBLIC_SPOT_URL`: Overwrites the URL of the [Spot](https://github.com/samply/spot) backend that your application queries
 
-For example you could handle the these variable as follows:
+Just like you created a JSON file `src/config/options.json` containing the empty object `{}`, create a `src/config/options-test.json` containing the empty object `{}`.
+
+Now you can handle these variables as follows:
 
 ```html
 <script lang="ts">

--- a/book/src/guide/new-app.md
+++ b/book/src/guide/new-app.md
@@ -83,8 +83,6 @@ Now run `npm run dev` and open <http://localhost:5173/> in your browser. You sho
 
 Your application must pass two objects to Lens. The [LensOptions](https://samply.github.io/lens/docs/types/LensOptions.html) object contains general configuration options and the [Catalogue](https://samply.github.io/lens/docs/types/Catalogue.html) object describes what users can search for. You can define these objects in TypeScript but many applications in the Samply organization define them in JSON files.
 
-> **NOTE:** Whenever we talk about configuring Lens through a JSON file, we are talking about the below mentioned `options.json` file. This file is being initialized with an empty object for now, but will be populated in the later parts of this book.
-
 Assuming you are using JSON files, create the file `src/config/options.json` containing the empty object `{}` and the file `src/config/catalogue.json` with the following content:
 
 ```json
@@ -133,6 +131,8 @@ Add the following to the top of `src/App.svelte` to load the JSON files and pass
 ```
 
 When you run `npm run dev` you should see the search bar and the catalogue component with the "Rh factor" entry. Open the "Rh factor" entry and click the plus icons next to Rh+ and Rh- in order to add them to the search bar.
+
+**NOTE:** The `options.json` file is being initialized with an empty object for now, but will be populated in the later parts of this book. Whenever the book tells you to add something to the Lens options it is implied that you add it to this file.
 
 ### Schema validation
 

--- a/book/src/guide/new-app.md
+++ b/book/src/guide/new-app.md
@@ -83,6 +83,8 @@ Now run `npm run dev` and open <http://localhost:5173/> in your browser. You sho
 
 Your application must pass two objects to Lens. The [LensOptions](https://samply.github.io/lens/docs/types/LensOptions.html) object contains general configuration options and the [Catalogue](https://samply.github.io/lens/docs/types/Catalogue.html) object describes what users can search for. You can define these objects in TypeScript but many applications in the Samply organization define them in JSON files.
 
+> **NOTE:** Whenever we talk about configuring Lens through a JSON file, we are talking about the below mentioned `options.json` file. This file is being initialized with an empty object for now, but will be populated in the later parts of this book.
+
 Assuming you are using JSON files, create the file `src/config/options.json` containing the empty object `{}` and the file `src/config/catalogue.json` with the following content:
 
 ```json
@@ -173,7 +175,7 @@ It is a common requirement to load different options in test and production. You
 - `PUBLIC_ENVIRONMENT`: Accepts the name of the environment, e.g. `production` or `test`
 - `PUBLIC_SPOT_URL`: Overwrites the URL of the [Spot](https://github.com/samply/spot) backend that your application queries
 
-Just like you created a JSON file `src/config/options.json` containing the empty object `{}`, create a `src/config/options-test.json` containing the empty object `{}`.
+Just like you created a JSON file `src/config/options.json`, create a `src/config/options-test.json` (to start with, it can also contain an empty object `{}`).
 
 Now you can handle these variables as follows:
 

--- a/book/src/guide/query.md
+++ b/book/src/guide/query.md
@@ -8,7 +8,7 @@ Once a user selects an element from the catalogue, it is added to the query stor
 
 ![Example of search bar](pics/search-bar-example.png)
 
-The query searches for patients with blood group A- and a body weight between 30 and 100 as well as patients with blood group B+ regardless of their body weight. In the query store this query is represented as follows:
+The query searches for patients with blood group A+ and a body weight between 30 and 100 as well as patients with blood group B+ regardless of their body weight. In the query store this query is represented as follows:
 
 ```json
 [

--- a/book/src/guide/results.md
+++ b/book/src/guide/results.md
@@ -24,7 +24,7 @@ When your application has [queried a backend](query.md) and receives results fro
 }
 ```
 
-The `totals` field contains the total number of patients, samples, etc. The `stratifiers` field contains stratum counts (e.g. male, female) for each stratier (e.g. gender). The specific stratifiers depend on the application. When you add a chart to your application you specify which stratifier it should display.
+The `totals` field contains the total number of patients, samples, etc. The `stratifiers` field contains stratum counts (e.g. male, female) for each stratifier (e.g. gender). The specific stratifiers depend on the application. When you add a chart to your application you specify which stratifier it should display.
 
 [Focus](https://github.com/samply/focus) can return the Lens result format directly. If you are quering a FHIR server you can convert a FHIR measure report to the Lens result format using the [`measureReportToLensResult`](https://samply.github.io/lens/docs/functions/measureReportToLensResult.html) function.
 


### PR DESCRIPTION
### Description

The following documentation fixes are dine -

- The code snippet for the file `.vscode/settings.json`, should have the enclosing `{}` braces
- The `Test environment` should mention creating `./config/options-test.json` file
- Remove the word `the` from the text - `you could handle the these variable`
- *Query Store* - Figure shows blood group `A+` whereas the text mentions `A-`
- *Showing results* - typo `stratier (e.g. gender)`?
- *Chart* - typo `setable` instead of `are set`, `Non` instead of `None`
- *Result Summary* - where to set `resultSummaryOptions`?
- *Result Table* - where to set `tableOptions`?