### PR TITLE
chore: show spinner when there are claimed sites

### DIFF
--- a/src/components/informational/QuerySpinner.wc.svelte
+++ b/src/components/informational/QuerySpinner.wc.svelte
@@ -9,21 +9,9 @@
 
     let { size = "20px" } = $props();
 
-    let loading = $state(false);
-
-    window.addEventListener("lens-search-triggered", function () {
-        loading = true;
-    });
-
-    $effect(() => {
-        if (
-            Array.from($siteStatus.values()).every(
-                (status) => status !== "claimed",
-            )
-        ) {
-            loading = false;
-        }
-    });
+    let loading = $derived.by(() =>
+        Array.from($siteStatus.values()).some((status) => status === "claimed"),
+    );
 </script>
 
 <div


### PR DESCRIPTION
This gets rid of any raciness that would lead to the spinner not showing in some circumstances. The question is if this is the logic we want. I would argue it is a pragmatic solution and good enough. Some flaws with this:
* Spinner is not showing until first site is claimed
* If there are no claimed sites temporarily and then more results come in the spinner will stop spinning temporarily: e.g. berlin claimed -> berlin succeeded -> hamburg claimed -> ... (We can't really solve this without knowing which sites will be queried in advance.)

Related discussion: #612 