### PR TITLE
fix(auto complete): center facet count to retain original height

### DIFF
--- a/src/components/catalogue/AutoCompleteComponent.svelte
+++ b/src/components/catalogue/AutoCompleteComponent.svelte
@@ -438,6 +438,7 @@
         display: grid;
         grid-template-columns: subgrid;
         grid-column: 1 / -1; /* Full width */
+        align-items: center;
         gap: var(--gap-xs);
         cursor: pointer;
         padding: var(--gap-xxs) var(--gap-xs); /* Match input field’s padding */


### PR DESCRIPTION
### Description
The facet count expands it height in the auto complete component, when the info text spans more than one line.
Fixed to maintain original height and center instead.

### Related Issue

<!--- Please link to the issue here: -->
https://github.com/samply/lens/issues/578

---

### How Has This Been Tested?
UI user test

<!--- Please describe in detail how you tested your changes. -->
<img width="453" height="257" alt="Screenshot 2025-09-04 at 12 50 15" src="https://github.com/user-attachments/assets/ca279685-744c-4067-b997-5425d3531e3c" />

<!--- Include details of your testing environment, and the tests you ran to -->
