### PR TITLE
chore: show ghost chart if no data is available

### DIFF
--- a/dev.svelte
+++ b/dev.svelte
@@ -6,8 +6,8 @@
         setSiteResult,
         getAst,
         showToast,
-        resetDiagrams,
         markSiteClaimed,
+        clearSiteResults,
     } from "./src/index";
     import { facetCounts } from "./src/stores/facetCounts";
 
@@ -323,8 +323,8 @@
     });
 
     window.addEventListener("lens-search-triggered", () => {
-        resetDiagrams();
         console.log("AST:", JSON.stringify(getAst()));
+        clearSiteResults();
         markSiteClaimed("riverside");
         markSiteClaimed("summit");
         for (const site of ["A", "B", "C", "D", "E"]) {

--- a/src/components/results/ChartComponent.wc.svelte
+++ b/src/components/results/ChartComponent.wc.svelte
@@ -401,12 +401,19 @@
          */
         let chartData: ChartDataSets = getChartDataSets(chartLabels);
 
-        // If the chart is empty and no responses are pending show "No Data Available"
-        noDataAvailable =
-            chartData.data[0].data.every((value) => value === 0) &&
-            Array.from(siteStatus.values()).every(
-                (status) => status !== "claimed",
-            );
+        // If there is no data, show ghost chart and return early
+        if (chartData.data[0].data.every((value) => value === 0)) {
+            resetChart();
+            if (
+                !Array.from(siteStatus.values()).some(
+                    (status) => status === "claimed",
+                )
+            ) {
+                // Show "No Data Available" if no responses are pending
+                noDataAvailable = true;
+            }
+            return;
+        }
 
         chart.data.datasets = chartData.data;
         chartLabels = chartData.labels;


### PR DESCRIPTION
https://github.com/user-attachments/assets/cf307047-fd66-4478-bf16-3e6578b04ffc

When there was no chart data the chart wouldn't render at all (see https://github.com/samply/lens/issues/632). This PR calls `resetChart()` in that case to show a ghost chart.

Closes https://github.com/samply/lens/issues/632