### PR TITLE
chore: rename hideFailedSites to removeFailedSite

### DIFF
--- a/book/src/guide/results.md
+++ b/book/src/guide/results.md
@@ -30,7 +30,7 @@ The `totals` field contains the total number of patients, samples, etc. The `str
 
 ## Passing results to Lens
 
-You pass results to Lens using the [`setSiteResult`](file:///home/tim/projects/lens/docs/functions/setSiteResult.html) function. Before you pass a result you may call [`markSiteClaimed`](https://samply.github.io/lens/docs/functions/markSiteClaimed.html) to indicate that the site is available and will deliver results soon. If a site that was claimed fails you can use [`hideFailedSite`](https://samply.github.io/lens/docs/functions/hideFailedSite.html) to hide the site from the result summary and result table. This examples shows how you would pass results from Focus to Lens.
+You pass results to Lens using the [`setSiteResult`](file:///home/tim/projects/lens/docs/functions/setSiteResult.html) function. Before you pass a result you may call [`markSiteClaimed`](https://samply.github.io/lens/docs/functions/markSiteClaimed.html) to indicate that the site is available and will deliver results soon. If a site that was claimed fails you can use [`removeFaileSite`](https://samply.github.io/lens/docs/functions/removeFaileSite.html) to hide the site from the result summary and result table and remove the site out of the resultstore. This examples shows how you would pass results from Focus to Lens.
 
 ```ts
 querySpot(query, abortController.signal, (result: SpotResult) => {
@@ -41,7 +41,7 @@ querySpot(query, abortController.signal, (result: SpotResult) => {
         const siteResult = JSON.parse(atob(result.body));
         setSiteResult(site, siteResult);
     } else {
-        hideFailedSite(site);
+        removeFaileSite(site);
         console.error(
             `Site ${site} failed with status ${result.status}:`,
             result.body,

--- a/book/src/releases/v0.6.3.md
+++ b/book/src/releases/v0.6.3.md
@@ -1,0 +1,9 @@
+# Version 0.6.3
+
+## Breaking Changes
+
+- changed _hideFailedSites_ to _removeFailedSite_
+
+## Migration Guide
+
+- rename _hideFailedSites_ to _removeFailedSite_

--- a/demo.svelte
+++ b/demo.svelte
@@ -7,7 +7,7 @@
         getAst,
         showToast,
         markSiteClaimed,
-        hideFailedSite,
+        removeFaileSite,
         setFacetCounts,
         clearSiteResults,
         getHumanReadableQueryAsFormattedString,
@@ -377,7 +377,7 @@
                 },
             });
 
-            hideFailedSite("failingsite");
+            removeFaileSite("failingsite");
 
             for (const site of "ABCDEFGHIJ") {
                 setSiteResult("Site " + site, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export { setQueryStoreFromAst } from "./helpers/ast-to-query";
 export {
     setSiteResult,
     markSiteClaimed,
-    hideFailedSite,
+    removeFaileSite,
     measureReportToLensResult,
     clearSiteResults,
     type LensResult,

--- a/src/stores/response.ts
+++ b/src/stores/response.ts
@@ -74,8 +74,8 @@ export function markSiteClaimed(site: string) {
     });
 }
 
-/** Call this to hide a failed site from the results. */
-export function hideFailedSite(site: string) {
+/** Call this to hide and remove a failed site from the results. */
+export function removeFaileSite(site: string) {
     siteStatus.update((sites) => {
         sites.delete(site);
         return sites;


### PR DESCRIPTION
BREAKING CHANGE: the naming of the function changed, please migrate it

Fixes #715 