### PR TITLE
chore: indicate table headers to be sortable

### DIFF
--- a/src/components/results/ResultTableComponent.wc.svelte
+++ b/src/components/results/ResultTableComponent.wc.svelte
@@ -221,6 +221,10 @@
                                 ▼
                             {/if}
                         </span>
+                    {:else}
+                        <span style="font-size: 0.3em; opacity: 0.5;">
+                            ▲▼
+                        </span>
                     {/if}
                 </th>
             {/each}

--- a/src/components/results/ResultTableComponent.wc.svelte
+++ b/src/components/results/ResultTableComponent.wc.svelte
@@ -214,7 +214,7 @@
                         <InfoButtonComponent message={header.hintText} />
                     {/if}
                     {#if index === sortColumnIndex}
-                        <span style="font-size: 0.8em;">
+                        <span style="font-size: clamp(12px, 0.8rem, 32px);">
                             {#if sortAscending}
                                 ▲
                             {:else}
@@ -222,7 +222,9 @@
                             {/if}
                         </span>
                     {:else}
-                        <span style="font-size: 0.3em; opacity: 0.5;">
+                        <span
+                            style="font-size: clamp(10px, 0.4rem, 22px); opacity: 0.5;"
+                        >
                             ▲▼
                         </span>
                     {/if}


### PR DESCRIPTION
### Description

This PR improves the headers of the result table and indicates it is sortable.

<img width="488" height="59" alt="Bildschirmfoto 2025-11-18 um 08 19 00" src="https://github.com/user-attachments/assets/dd7a8f6e-9663-42f3-9cac-cf20f036d8dc" />
