### PR TITLE
Add indicateApproximation prop to result table and result summary

### DIFF
--- a/book/src/components/resultsummary.md
+++ b/book/src/components/resultsummary.md
@@ -4,6 +4,12 @@ The `lens-result-summary` component displays a compact summary of result metrics
 
 ---
 
+## Props
+
+| Prop                    | Type      | Default | Description                                                            |
+| ----------------------- | --------- | ------- | ---------------------------------------------------------------------- |
+| `indicateApproximation` | `boolean` | `false` | Visually indicate that values are approximations (e.g., with a tilde). |
+
 ## Example
 
 To use the component, define the configuration in the Lens [resultSummaryOptions](https://samply.github.io/lens/docs/types/ResultSummaryOptions.html) (as described in the [Options and catalogue](../guide/new-app.md#options-and-catalogue) section):

--- a/book/src/components/resulttable.md
+++ b/book/src/components/resulttable.md
@@ -12,10 +12,11 @@ Each row includes a checkbox to select that data source for a data request. The 
 
 ## Props
 
-| Prop       | Type     | Default | Description                                                         |
-| ---------- | -------- | ------- | ------------------------------------------------------------------- |
-| `title`    | `string` | `""`    | Optional title displayed above the table.                           |
-| `pageSize` | `number` |         | If set, limits the number of rows displayed and enables pagination. |
+| Prop                    | Type      | Default | Description                                                            |
+| ----------------------- | --------- | ------- | ---------------------------------------------------------------------- |
+| `title`                 | `string`  | `""`    | Optional title displayed above the table.                              |
+| `pageSize`              | `number`  |         | If set, limits the number of rows displayed and enables pagination.    |
+| `indicateApproximation` | `boolean` | `false` | Visually indicate that values are approximations (e.g., with a tilde). |
 
 ## Slots
 

--- a/book/src/releases/v0.6.3.md
+++ b/book/src/releases/v0.6.3.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Charts now support sorting by value or alphabetically with visual toggle buttons that indicate sort direction. Enable this feature by setting the `enableSorting` prop to `true`. Defaults to alphabetical ascending sort.
+- Added optional `indicateApproximation` prop to result table and result summary components, that shows a visual indication that the numbers in the table/summary are approximations.
 
 ## Breaking changes
 

--- a/src/components/results/ResultSummaryComponent.wc.svelte
+++ b/src/components/results/ResultSummaryComponent.wc.svelte
@@ -17,7 +17,7 @@
     import type { HeaderData } from "../../types/options";
 
     interface Props {
-        /** Visually indicate that values are approximate (e.g., with a tilde). */
+        /** Visually indicate that values are approximations (e.g., with a tilde). */
         indicateApproximation?: boolean;
     }
     let { indicateApproximation = false }: Props = $props();

--- a/src/components/results/ResultSummaryComponent.wc.svelte
+++ b/src/components/results/ResultSummaryComponent.wc.svelte
@@ -16,6 +16,12 @@
     import InfoButtonComponent from "../buttons/InfoButtonComponent.wc.svelte";
     import type { HeaderData } from "../../types/options";
 
+    interface Props {
+        /** Visually indicate that values are approximate (e.g., with a tilde). */
+        indicateApproximation?: boolean;
+    }
+    let { indicateApproximation = false }: Props = $props();
+
     // This is derived from lensOptions and from responseStore
     const populations: { title: string; population: string }[] = $derived.by(
         () => {
@@ -62,32 +68,35 @@
             return `${sitesWithData} / ${sitesClaimed}`;
         }
 
-        // if the type has only one dataKey, the population is the aggregated population of that dataKey
+        let population: number;
         if (type.dataKey) {
-            return getTotal(siteResults, type.dataKey).toString();
+            // if the type has only one dataKey, the population is the aggregated population of that dataKey
+            population = getTotal(siteResults, type.dataKey);
+        } else {
+            // if the type has multiple dataKeys to aggregate, the population is the aggregated population of all dataKeys
+            population = 0;
+            type.aggregatedDataKeys?.forEach((dataKey) => {
+                if (dataKey.groupCode) {
+                    population += getTotal(siteResults, dataKey.groupCode);
+                } else if (dataKey.stratifierCode && dataKey.stratumCode) {
+                    population += getStratum(
+                        siteResults,
+                        dataKey.stratifierCode,
+                        dataKey.stratumCode,
+                    );
+                }
+                /**
+                 * TODO: add support for stratifiers if needed?
+                 * needs to be implemented in response.ts
+                 */
+            });
         }
 
-        // if the type has multiple dataKeys to aggregate, the population is the aggregated population of all dataKeys
-        let aggregatedPopulation: number = 0;
-        type.aggregatedDataKeys?.forEach((dataKey) => {
-            if (dataKey.groupCode) {
-                aggregatedPopulation += getTotal(
-                    siteResults,
-                    dataKey.groupCode,
-                );
-            } else if (dataKey.stratifierCode && dataKey.stratumCode) {
-                aggregatedPopulation += getStratum(
-                    siteResults,
-                    dataKey.stratifierCode,
-                    dataKey.stratumCode,
-                );
-            }
-            /**
-             * TODO: add support for stratifiers if needed?
-             * needs to be implemented in response.ts
-             */
-        });
-        return aggregatedPopulation.toString();
+        if (indicateApproximation) {
+            return `≈ ${population}`;
+        } else {
+            return population.toString();
+        }
     }
 </script>
 

--- a/src/components/results/ResultTableComponent.wc.svelte
+++ b/src/components/results/ResultTableComponent.wc.svelte
@@ -139,9 +139,15 @@
         title?: string;
         /** If set, limits the number of rows displayed and enables pagination. */
         pageSize?: number;
+        /** Visually indicate that values are approximate (e.g., with a tilde). */
+        indicateApproximation?: boolean;
     }
 
-    let { title = "", pageSize }: Props = $props();
+    let {
+        title = "",
+        pageSize,
+        indicateApproximation = false,
+    }: Props = $props();
 
     let activePage = $state(1);
     let sortColumnIndex = $state(0);
@@ -247,7 +253,12 @@
                     /></td
                 >
                 {#each tableRow as data, index (index)}
-                    <td part="lens-result-table-item-body-cell">{data}</td>
+                    <td part="lens-result-table-item-body-cell">
+                        {#if indicateApproximation && index !== 0 && typeof data === "number"}
+                            ≈
+                        {/if}
+                        {data}
+                    </td>
                 {/each}
             </tr>
         {/each}

--- a/src/components/results/ResultTableComponent.wc.svelte
+++ b/src/components/results/ResultTableComponent.wc.svelte
@@ -139,7 +139,7 @@
         title?: string;
         /** If set, limits the number of rows displayed and enables pagination. */
         pageSize?: number;
-        /** Visually indicate that values are approximate (e.g., with a tilde). */
+        /** Visually indicate that values are approximations (e.g., with a tilde). */
         indicateApproximation?: boolean;
     }
 


### PR DESCRIPTION
Here example in BBMRI sample locator:

<img width="1286" height="755" alt="image" src="https://github.com/user-attachments/assets/cae788ae-e547-4752-8de5-ff4dae8a3655" />

Do you think it is worth doing for the result summary or is it sufficient if we add the symbol only to the result table?