### PR TITLE
fix(searchbar): make tab work when no input list item is selected

### DIFF
--- a/src/components/search-bar/SearchBarComponent.wc.svelte
+++ b/src/components/search-bar/SearchBarComponent.wc.svelte
@@ -371,6 +371,7 @@
                 return;
             } else if (
                 (focusedListItem || searchBarInputHasFoucs || event.shiftKey) &&
+                activeDomElement &&
                 activeDomElement !== focusedListItem
             ) {
                 event.preventDefault();


### PR DESCRIPTION
### Description
Fix bug, where the focus would not jump to the first input in the search bar options when there was no active element
