### PR TITLE
feat: remove empty search bars on search

### DIFF
--- a/src/components/buttons/SearchButtonComponent.wc.svelte
+++ b/src/components/buttons/SearchButtonComponent.wc.svelte
@@ -6,7 +6,7 @@
 
 <script lang="ts">
     import { translate } from "../../helpers/translations";
-    import { queryModified } from "../../stores/query";
+    import { queryModified, queryStore } from "../../stores/query";
 
     interface Props {
         title?: string;
@@ -17,6 +17,7 @@
 
     const onclick = (): void => {
         queryModified.set(false);
+        $queryStore = $queryStore.filter((queryGroup) => queryGroup.length > 0);
         window.dispatchEvent(new CustomEvent("lens-search-triggered"));
     };
 </script>

--- a/src/components/buttons/SearchButtonComponent.wc.svelte
+++ b/src/components/buttons/SearchButtonComponent.wc.svelte
@@ -18,6 +18,9 @@
     const onclick = (): void => {
         queryModified.set(false);
         $queryStore = $queryStore.filter((queryGroup) => queryGroup.length > 0);
+        if ($queryStore.length === 0) {
+            $queryStore = [[]];
+        }
         window.dispatchEvent(new CustomEvent("lens-search-triggered"));
     };
 </script>


### PR DESCRIPTION
### Description
Empty search bars should be deleted when the search is triggered to prevent the AST to have an empty OR
### Related Issue

<!--- Please link to the issue here: -->
https://github.com/samply/lens/issues/743
