### PR TITLE
Only send credentials to spot and prism backends if same-origin

### DIFF
--- a/src/backends/spot.ts
+++ b/src/backends/spot.ts
@@ -35,7 +35,6 @@ export async function querySpot(
         headers: {
             "Content-Type": "application/json",
         },
-        credentials: "include",
         body: JSON.stringify({
             id,
             sites,
@@ -58,9 +57,6 @@ export async function querySpot(
     const eventSource = new EventSource(
         `${url}/beam/${id}` +
             (sites !== undefined ? `?wait_count=${sites.length}` : ""),
-        {
-            withCredentials: true,
-        },
     );
 
     eventSource.addEventListener("error", () => {


### PR DESCRIPTION
Requests are always same-origin in production when Traefik auth is used since frontend, spot and prism live in the same Docker stack and share auth. This change was made so in local test environments wildcard CORS origin can be used (this would conflict with sending credentials).

### Description

### Related Issue

<!--- Please link to the issue here: -->

---

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
